### PR TITLE
chore: restructure devlogs to branch-scoped files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,6 +366,7 @@ See BUILD_STATUS.md and PLAN.md for detailed implementation plan.
 - **Start of each working session:** Create the branch's devlog file if it doesn't exist, or add a new `## Session` header to the existing file
 - **During work:** Update the current session as you make changes, decisions, or discoveries
 - **One file per branch.** New session on same branch = new `## Session N` header in the same file.
+- **Main is protected** — all work goes through PRs. Devlogs are created on feature branches and arrive on main via merge.
 
 ### File Naming
 
@@ -376,10 +377,9 @@ Format: `devlog/NNNNNN-<branch-name>.md` — **one file per branch**.
 - Multiple sessions on the same branch use `## Session N — Topic` headers within the file
 
 **Assigning the sequence number:**
-1. Before merging your PR, rebase onto main (required by branch protection)
-2. Check the highest existing number in `devlog/`
-3. Use the next number for your file
-4. This is safe because branches must be up-to-date with main before merging
+1. At the start of your branch, check the highest existing number in `devlog/` and use the next one
+2. If the number conflicts when merging (another PR merged first), rebase onto main and renumber your file
+3. This is safe because branches must be up-to-date with main before merging — a conflict means the devlog has advanced and a rebase is required anyway
 
 ### What to Log
 
@@ -393,7 +393,7 @@ Format: `devlog/NNNNNN-<branch-name>.md` — **one file per branch**.
 - **Lessons Learned:** Reusable insights from this session — patterns that worked well, pitfalls to avoid, API quirks discovered, or conventions established. If nothing new was learned, leave this section empty or omit it. These should be things a future session would benefit from knowing.
 - **Commits:** List commit hashes and messages created during the session
 
-**End-of-file section** (at the bottom of the file):
+**End-of-file section** (at the bottom of the file, optional for single-session branches):
 - **Next Steps:** What's left or what to pick up next (shared across sessions)
 
 ### Guidelines
@@ -417,7 +417,7 @@ Format: `devlog/NNNNNN-<branch-name>.md` — **one file per branch**.
   - What approach you used instead
 
   Failed attempts are valuable knowledge.
-- **Append-only editing** — When updating existing session entries, **only add new information**. Never delete or overwrite content written by a previous session or agent. You may update lines within your own current session to reflect the final state (e.g., correcting a "What Changed" entry you wrote minutes ago), but entries from prior sessions are immutable. If earlier information turns out to be wrong, add a correction note rather than removing the original.
+- **Append-only across sessions** — You may freely update entries within your own current session, but entries from prior sessions are immutable. If earlier information turns out to be wrong, add a correction note rather than removing the original.
 
 ### Example Structure
 
@@ -451,7 +451,7 @@ Format: `devlog/NNNNNN-<branch-name>.md` — **one file per branch**.
 
 ---
 
-## Session 2 — Another Topic (HH:MM TZ, model-name)
+## Session 2 — Another Topic (YYYY-MM-DD HH:MM TZ, model-name)
 ...
 
 ---

--- a/devlog/000001-initial-scaffolding.md
+++ b/devlog/000001-initial-scaffolding.md
@@ -1,4 +1,4 @@
-# 2026-02-14
+# 000001-initial-scaffolding
 
 ## Session 1 — Project Scaffolding (10:00 PST, sonnet-4-5)
 

--- a/devlog/000002-chore-devlog-branch-scoped.md
+++ b/devlog/000002-chore-devlog-branch-scoped.md
@@ -1,0 +1,27 @@
+# 000002-chore-devlog-branch-scoped
+
+## Session 1 — Restructure devlogs for PR workflows (2026-02-14 23:00 PST, opus-4-6)
+
+**Agent:** Claude Code (claude-opus-4-6) @ `prism` branch `chore/devlog-branch-scoped`
+
+### Intent
+Restructure devlog naming from date-based (`YYYY-MM-DD.md`) to branch-scoped (`NNNNNN-branch-name.md`) with 6-digit sequence number prefixes. The date-based scheme caused merge conflicts when multiple branches worked on the same day. Branch-scoped files eliminate collisions entirely.
+
+### What Changed
+- **[2026-02-14 23:00 PST]** `devlog/2026-02-14.md` → `devlog/000001-initial-scaffolding.md` — Renamed to new convention. Updated H1 heading to match filename.
+- **[2026-02-14 23:00 PST]** `devlog/README.md` — Rewritten with branch-scoped naming, 6-digit prefix, and sequence number assignment instructions.
+- **[2026-02-14 23:00 PST]** `AGENTS.md` — Updated Session Logs section: branch-scoped files, sequence number workflow (assign at branch start, renumber on conflict during rebase), main is protected, simplified append-only guideline, Next Steps optional for single-session branches, fixed inconsistent example headers.
+- **[2026-02-14 23:11 PST]** `devlog/000002-chore-devlog-branch-scoped.md` — Created devlog for this branch.
+
+### Decisions
+- **[2026-02-14 23:00 PST]** **Assign sequence number at branch start, not before merge** — Simpler workflow. If it conflicts at merge time, the branch needs rebasing anyway (branch protection requires up-to-date), at which point the number gets updated.
+- **[2026-02-14 23:00 PST]** **6-digit prefix** — Sufficient for 999,999 entries. Sorts lexicographically.
+- **[2026-02-14 23:00 PST]** **No devlogs directly on main** — Main is protected; all work goes through PRs. Devlog files arrive on main via merge.
+
+### Issues
+- **[RESOLVED] Sequence number workflow gap** — Initial version said to create the file at session start but assign the number before merge. Fixed: assign at start, renumber on conflict.
+- **[RESOLVED] Example structure inconsistency** — Session 2 header was missing the date. Fixed.
+- **[RESOLVED] Stale H1 heading** — `000001-initial-scaffolding.md` still had `# 2026-02-14`. Fixed to match filename.
+
+### Commits
+- `5bc712b` — chore: restructure devlogs to branch-scoped files with sequence numbers

--- a/devlog/README.md
+++ b/devlog/README.md
@@ -21,10 +21,9 @@ Format: `NNNNNN-<branch-name>.md` — **one file per branch**.
 
 ### Assigning the sequence number
 
-1. Before merging your PR, rebase onto main (required by branch protection)
-2. Check the highest existing number in `devlog/`
-3. Use the next number for your file
-4. This is safe because branches must be up-to-date with main before merging
+1. At the start of your branch, check the highest existing number in `devlog/` and use the next one
+2. If the number conflicts when merging (another PR merged first), rebase onto main and renumber your file
+3. This is safe because branches must be up-to-date with main before merging — a conflict means the devlog has advanced and a rebase is required anyway
 
 ## Reading the Log
 


### PR DESCRIPTION
Restructure devlog naming from date-based to branch-scoped files with 6-digit sequence number prefixes, eliminating merge conflicts when multiple branches work in parallel.

- Rename devlog files from date-based (`YYYY-MM-DD.md`) to branch-scoped (`NNNNNN-branch-name.md`)
- Add 6-digit sequence number prefix for chronological ordering
- Update AGENTS.md and devlog/README.md conventions
- Sequence numbers assigned before merge when branch is up-to-date with main