### PR TITLE
chore: harden Apple CI with composite action, xcodebuild, and native FileReader

### DIFF
--- a/.github/actions/setup-wgpu4k/action.yml
+++ b/.github/actions/setup-wgpu4k/action.yml
@@ -1,0 +1,104 @@
+name: Setup wgpu4k
+description: Build wgpu4k from source (or restore from cache) and publish to Maven Local
+
+inputs:
+  rust-targets:
+    description: Extra Rust targets for cross-compilation (comma-separated, e.g. aarch64-apple-ios,aarch64-apple-ios-sim)
+    required: false
+    default: ""
+
+outputs:
+  version:
+    description: wgpu4k version string
+    value: ${{ steps.wgpu4k-version.outputs.version }}
+  commit:
+    description: wgpu4k commit hash
+    value: ${{ steps.wgpu4k-version.outputs.commit }}
+  cache-hit:
+    description: Whether wgpu4k was restored from cache
+    value: ${{ steps.cache-wgpu4k.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get wgpu4k version
+      id: wgpu4k-version
+      shell: bash
+      run: |
+        VERSION=$(grep '^wgpu4k ' gradle/libs.versions.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+        COMMIT=$(grep '^wgpu4kCommit' gradle/libs.versions.toml | sed 's/.*"\(.*\)".*/\1/')
+        if [ -z "$VERSION" ] || [ -z "$COMMIT" ]; then
+          echo "::error::Failed to extract wgpu4k version/commit from libs.versions.toml"
+          exit 1
+        fi
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
+        echo "wgpu4k version: $VERSION @ $COMMIT"
+
+    - name: Cache wgpu4k Maven Local
+      id: cache-wgpu4k
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2/repository/io/ygdrasil
+        key: wgpu4k-${{ runner.os }}-${{ steps.wgpu4k-version.outputs.commit }}
+
+    - name: Set up Rust toolchain
+      if: steps.cache-wgpu4k.outputs.cache-hit != 'true'
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: ${{ inputs.rust-targets }}
+
+    - name: Cache Rust toolchain
+      if: steps.cache-wgpu4k.outputs.cache-hit != 'true'
+      uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: wgpu4k-rust
+
+    - name: Build wgpu4k from source
+      if: steps.cache-wgpu4k.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        WGPU4K_COMMIT: ${{ steps.wgpu4k-version.outputs.commit }}
+      run: |
+        CLONE_START=$SECONDS
+        git init /tmp/wgpu4k
+        cd /tmp/wgpu4k
+        git remote add origin https://github.com/wgpu4k/wgpu4k.git
+        git fetch --depth 1 origin "$WGPU4K_COMMIT"
+        git checkout FETCH_HEAD
+        CLONE_TIME=$((SECONDS - CLONE_START))
+
+        BUILD_START=$SECONDS
+        ./gradlew publishToMavenLocal --no-daemon -x dokkaHtml -x dokkaGenerate -x dokkaGenerateHtml
+        BUILD_TIME=$((SECONDS - BUILD_START))
+
+        TOTAL_TIME=$((SECONDS - CLONE_START))
+        ARTIFACT_COUNT=$(find ~/.m2/repository/io/ygdrasil -type f | wc -l)
+        ARTIFACT_SIZE=$(du -sh ~/.m2/repository/io/ygdrasil | cut -f1)
+
+        echo "### wgpu4k Build" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
+        echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Clone time | ${CLONE_TIME}s |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Build time | ${BUILD_TIME}s |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Total time | ${TOTAL_TIME}s |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Artifacts | ${ARTIFACT_COUNT} files (${ARTIFACT_SIZE}) |" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Cache status diagnostics
+      shell: bash
+      env:
+        WGPU4K_VERSION: ${{ steps.wgpu4k-version.outputs.version }}
+        WGPU4K_COMMIT: ${{ steps.wgpu4k-version.outputs.commit }}
+        CACHE_HIT: ${{ steps.cache-wgpu4k.outputs.cache-hit }}
+      run: |
+        echo "### Cache Status" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Key | Value |" >> "$GITHUB_STEP_SUMMARY"
+        echo "|-----|-------|" >> "$GITHUB_STEP_SUMMARY"
+        echo "| wgpu4k version | ${WGPU4K_VERSION} |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| wgpu4k commit | \`${WGPU4K_COMMIT}\` |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Cache key | \`wgpu4k-${RUNNER_OS}-${WGPU4K_COMMIT}\` |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Cache hit | ${CACHE_HIT} |" >> "$GITHUB_STEP_SUMMARY"
+        if [ -d ~/.m2/repository/io/ygdrasil ]; then
+          SIZE=$(du -sh ~/.m2/repository/io/ygdrasil | cut -f1)
+          echo "| Artifact size | ${SIZE} |" >> "$GITHUB_STEP_SUMMARY"
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,83 +40,8 @@ jobs:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           add-job-summary: always
 
-      - name: Get wgpu4k version
-        id: wgpu4k-version
-        run: |
-          VERSION=$(grep '^wgpu4k ' gradle/libs.versions.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          COMMIT=$(grep '^wgpu4kCommit' gradle/libs.versions.toml | sed 's/.*"\(.*\)".*/\1/')
-          if [ -z "$VERSION" ] || [ -z "$COMMIT" ]; then
-            echo "::error::Failed to extract wgpu4k version/commit from libs.versions.toml"
-            exit 1
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
-          echo "wgpu4k version: $VERSION @ $COMMIT"
-
-      - name: Cache wgpu4k Maven Local
-        id: cache-wgpu4k
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository/io/ygdrasil
-          key: wgpu4k-${{ runner.os }}-${{ steps.wgpu4k-version.outputs.commit }}
-
-      - name: Set up Rust toolchain
-        if: steps.cache-wgpu4k.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust toolchain
-        if: steps.cache-wgpu4k.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: wgpu4k-rust
-
-      - name: Build wgpu4k from source
-        if: steps.cache-wgpu4k.outputs.cache-hit != 'true'
-        timeout-minutes: 15
-        env:
-          WGPU4K_COMMIT: ${{ steps.wgpu4k-version.outputs.commit }}
-        run: |
-          CLONE_START=$SECONDS
-          git init /tmp/wgpu4k
-          cd /tmp/wgpu4k
-          git remote add origin https://github.com/wgpu4k/wgpu4k.git
-          git fetch --depth 1 origin "$WGPU4K_COMMIT"
-          git checkout FETCH_HEAD
-          CLONE_TIME=$((SECONDS - CLONE_START))
-
-          BUILD_START=$SECONDS
-          ./gradlew publishToMavenLocal --no-daemon -x dokkaHtml -x dokkaGenerate -x dokkaGenerateHtml
-          BUILD_TIME=$((SECONDS - BUILD_START))
-
-          TOTAL_TIME=$((SECONDS - CLONE_START))
-          ARTIFACT_COUNT=$(find ~/.m2/repository/io/ygdrasil -type f | wc -l)
-          ARTIFACT_SIZE=$(du -sh ~/.m2/repository/io/ygdrasil | cut -f1)
-
-          echo "### wgpu4k Build" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Clone time | ${CLONE_TIME}s |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Build time | ${BUILD_TIME}s |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Total time | ${TOTAL_TIME}s |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Artifacts | ${ARTIFACT_COUNT} files (${ARTIFACT_SIZE}) |" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Cache status diagnostics
-        env:
-          WGPU4K_VERSION: ${{ steps.wgpu4k-version.outputs.version }}
-          WGPU4K_COMMIT: ${{ steps.wgpu4k-version.outputs.commit }}
-          CACHE_HIT: ${{ steps.cache-wgpu4k.outputs.cache-hit }}
-        run: |
-          echo "### Cache Status" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Key | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-----|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| wgpu4k version | ${WGPU4K_VERSION} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| wgpu4k commit | \`${WGPU4K_COMMIT}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Cache key | \`wgpu4k-${RUNNER_OS}-${WGPU4K_COMMIT}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Cache hit | ${CACHE_HIT} |" >> "$GITHUB_STEP_SUMMARY"
-          if [ -d ~/.m2/repository/io/ygdrasil ]; then
-            SIZE=$(du -sh ~/.m2/repository/io/ygdrasil | cut -f1)
-            echo "| Artifact size | ${SIZE} |" >> "$GITHUB_STEP_SUMMARY"
-          fi
+      - name: Setup wgpu4k
+        uses: ./.github/actions/setup-wgpu4k
 
       - name: Check formatting & static analysis
         run: |
@@ -150,7 +75,7 @@ jobs:
 
   apple:
     name: Apple Targets
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 45
 
     steps:
@@ -191,85 +116,60 @@ jobs:
           path: ~/.konan
           key: ${{ runner.os }}-konan-${{ steps.kotlin-version.outputs.version }}
 
-      - name: Get wgpu4k version
-        id: wgpu4k-version
-        run: |
-          VERSION=$(grep '^wgpu4k ' gradle/libs.versions.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          COMMIT=$(grep '^wgpu4kCommit' gradle/libs.versions.toml | sed 's/.*"\(.*\)".*/\1/')
-          if [ -z "$VERSION" ] || [ -z "$COMMIT" ]; then
-            echo "::error::Failed to extract wgpu4k version/commit from libs.versions.toml"
-            exit 1
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
-          echo "wgpu4k version: $VERSION @ $COMMIT"
-
-      - name: Cache wgpu4k Maven Local
-        id: cache-wgpu4k
-        uses: actions/cache@v4
+      - name: Setup wgpu4k
+        uses: ./.github/actions/setup-wgpu4k
         with:
-          path: ~/.m2/repository/io/ygdrasil
-          key: wgpu4k-${{ runner.os }}-${{ steps.wgpu4k-version.outputs.commit }}
+          rust-targets: aarch64-apple-ios,aarch64-apple-ios-sim
 
-      - name: Set up Rust toolchain
-        if: steps.cache-wgpu4k.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-ios,aarch64-apple-ios-sim
-
-      - name: Cache Rust toolchain
-        if: steps.cache-wgpu4k.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: wgpu4k-rust
-
-      - name: Build wgpu4k from source
-        if: steps.cache-wgpu4k.outputs.cache-hit != 'true'
-        timeout-minutes: 25
-        env:
-          WGPU4K_COMMIT: ${{ steps.wgpu4k-version.outputs.commit }}
-        run: |
-          CLONE_START=$SECONDS
-          git init /tmp/wgpu4k
-          cd /tmp/wgpu4k
-          git remote add origin https://github.com/wgpu4k/wgpu4k.git
-          git fetch --depth 1 origin "$WGPU4K_COMMIT"
-          git checkout FETCH_HEAD
-          CLONE_TIME=$((SECONDS - CLONE_START))
-
-          BUILD_START=$SECONDS
-          ./gradlew publishToMavenLocal --no-daemon -x dokkaHtml -x dokkaGenerate -x dokkaGenerateHtml
-          BUILD_TIME=$((SECONDS - BUILD_START))
-
-          TOTAL_TIME=$((SECONDS - CLONE_START))
-          ARTIFACT_COUNT=$(find ~/.m2/repository/io/ygdrasil -type f | wc -l)
-          ARTIFACT_SIZE=$(du -sh ~/.m2/repository/io/ygdrasil | cut -f1)
-
-          echo "### wgpu4k Build (macOS)" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Clone time | ${CLONE_TIME}s |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Build time | ${BUILD_TIME}s |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Total time | ${TOTAL_TIME}s |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Artifacts | ${ARTIFACT_COUNT} files (${ARTIFACT_SIZE}) |" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: iOS tests + XCFramework
+      - name: Apple native tests + XCFramework
         run: |
           START=$SECONDS
-          ./gradlew iosSimulatorArm64Test :prism-demo:assemblePrismDemoDebugXCFramework \
+          ./gradlew macosArm64Test iosSimulatorArm64Test \
+            :prism-demo:assemblePrismDemoDebugXCFramework \
             --configuration-cache-problems=warn \
             -Pkotlin.native.parallelThreads=3 || EXIT=$?
-          echo "### iOS Tests + XCFramework: $((SECONDS - START))s" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Apple Tests + XCFramework: $((SECONDS - START))s" >> "$GITHUB_STEP_SUMMARY"
           exit ${EXIT:-0}
 
       - name: Verify XCFramework exports
         run: |
-          HEADER="prism-demo/build/XCFrameworks/debug/PrismDemo.xcframework/ios-arm64-simulator/PrismDemo.framework/Headers/PrismDemo.h"
-          if [ ! -f "$HEADER" ]; then
-            echo "::error::XCFramework header not found at $HEADER"
-            exit 1
-          fi
+          XCF_ROOT="prism-demo/build/XCFrameworks/debug/PrismDemo.xcframework"
           echo "### XCFramework Verification" >> "$GITHUB_STEP_SUMMARY"
-          echo "Header found: \`$HEADER\`" >> "$GITHUB_STEP_SUMMARY"
-          EXPORTED_TYPES=$(grep -c '@interface PrismDemo' "$HEADER" || true)
-          echo "Exported types: ${EXPORTED_TYPES}" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Slice | Header | Exported Types |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|--------|----------------|" >> "$GITHUB_STEP_SUMMARY"
+
+          FAIL=0
+          for SLICE in ios-arm64 ios-arm64-simulator; do
+            HEADER="${XCF_ROOT}/${SLICE}/PrismDemo.framework/Headers/PrismDemo.h"
+            if [ -f "$HEADER" ]; then
+              TYPES=$(grep -c '@interface PrismDemo' "$HEADER" || true)
+              echo "| ${SLICE} | Found | ${TYPES} |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| ${SLICE} | **MISSING** | - |" >> "$GITHUB_STEP_SUMMARY"
+              echo "::error::XCFramework header not found: ${HEADER}"
+              FAIL=1
+            fi
+          done
+          exit $FAIL
+
+      - name: Upload XCFramework
+        uses: actions/upload-artifact@v4
+        with:
+          name: PrismDemo-debug.xcframework
+          path: prism-demo/build/XCFrameworks/debug/PrismDemo.xcframework
+          retention-days: 14
+
+      - name: Generate Xcode project
+        run: |
+          brew install xcodegen
+          cd prism-ios-demo && xcodegen generate
+
+      - name: Build iOS app
+        run: |
+          set -o pipefail
+          START=$SECONDS
+          xcodebuild -project prism-ios-demo/PrismiOSDemo.xcodeproj \
+            -scheme PrismiOSDemo -sdk iphonesimulator -arch arm64 \
+            -configuration Debug CODE_SIGNING_ALLOWED=NO build 2>&1 | tail -30 || EXIT=$?
+          echo "### xcodebuild: $((SECONDS - START))s" >> "$GITHUB_STEP_SUMMARY"
+          exit ${EXIT:-0}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Prism is a modular, cross-platform 3D game engine built with Kotlin Multiplatfor
 # Build demo for specific platform
 ./gradlew :prism-demo:jvmJar            # JVM executable JAR
 ./gradlew :prism-demo:wasmJsBrowserDistribution  # WASM for web
-./gradlew assemblePrismDemoReleaseXCFramework     # iOS XCFramework
+./gradlew assemblePrismDemoDebugXCFramework        # iOS XCFramework (debug)
 
 # Generate Xcode project (requires xcodegen: brew install xcodegen)
 cd prism-ios-demo && xcodegen generate

--- a/BUILD_STATUS.md
+++ b/BUILD_STATUS.md
@@ -102,7 +102,8 @@
 - Thread safety: `NSOperationQueue.mainQueue` for Compose state dispatch from Metal render thread
 - Lazy wgpu init via `viewDidAppear` with `isPaused` guard to avoid double GPU memory
 - `renderer.resize()` called on drawable size change for correct depth texture recreation
-- **Status:** Complete — `./gradlew assemblePrismDemoReleaseXCFramework` builds; Xcode project ready with two demos
+- prism-assets FileReader: nativeMain actual using kotlinx.io SystemFileSystem (covers all native targets); iosMain TODO stub removed
+- **Status:** Complete — `./gradlew assemblePrismDemoDebugXCFramework` builds; Xcode project ready with two demos
 ### M8: Android Support ⏳
 ### M9: PBR Materials ⏳
 ### M10: glTF Asset Loading ⏳
@@ -117,14 +118,17 @@
 | prism-demo | 8 | DemoStore (MVI reducer, 8) |
 | **Total** | **178** | |
 
-Run all tests: `./gradlew jvmTest`
+Run tests: `./gradlew jvmTest` (JVM) or `./gradlew macosArm64Test iosSimulatorArm64Test` (Apple native)
 
 ## Code Quality
 
 - [x] KtFmt (Google style, 100-char max width) via `./gradlew ktfmtCheck`
 - [x] Detekt (maxIssues=0) via `./gradlew detektJvmMain`
 - [x] `allWarningsAsErrors=true` on all modules
-- [x] GitHub Actions CI: ktfmtCheck + detekt + jvmTest on every push/PR
+- [x] GitHub Actions CI (two jobs on every push/PR):
+  - `ci` (ubuntu-latest): ktfmtCheck + detekt + jvmTest
+  - `apple` (macos-15): macosArm64Test + iosSimulatorArm64Test + XCFramework build/verify + artifact upload + xcodebuild
+  - wgpu4k build deduplicated into composite action (`.github/actions/setup-wgpu4k`)
 
 ## Build Commands
 
@@ -144,8 +148,8 @@ Run all tests: `./gradlew jvmTest`
 # Run demo app (WASM/Browser)
 ./gradlew :prism-demo:wasmJsBrowserDevelopmentRun
 
-# Build iOS XCFramework
-./gradlew assemblePrismDemoReleaseXCFramework
+# Build iOS XCFramework (debug)
+./gradlew assemblePrismDemoDebugXCFramework
 
 # Generate Xcode project (requires xcodegen: brew install xcodegen)
 cd prism-ios-demo && xcodegen generate

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ cd prism
 | Kotlin | 2.3.0 |
 | Gradle | 9.2.0 |
 | wgpu4k | 0.2.0-SNAPSHOT (`3fc6e327`) |
-| Compose Multiplatform | 1.10.0 |
+| Compose Multiplatform | 1.10.1 |
 | kotlinx-coroutines | 1.10.2 |
 | kotlinx-serialization | 1.9.0 |
 | kotlinx-io | 0.8.2 |
@@ -118,7 +118,7 @@ See [BUILD_STATUS.md](BUILD_STATUS.md) for detailed status and [PLAN.md](PLAN.md
 
 ## Testing
 
-Tests use `kotlin.test` with [Kotest](https://kotest.io/) assertion matchers. All tests run on JVM via `./gradlew jvmTest`.
+Tests use `kotlin.test` with [Kotest](https://kotest.io/) assertion matchers. CI runs two jobs: `jvmTest` on Ubuntu and `macosArm64Test` + `iosSimulatorArm64Test` on macOS.
 
 | Module | Tests | Coverage |
 |---|---|---|

--- a/devlog/plans/000008-01-ci-improvements.md
+++ b/devlog/plans/000008-01-ci-improvements.md
@@ -1,0 +1,72 @@
+# Plan: Improve CI workflow for XCFramework and iOS builds
+
+## Thinking
+
+The `apple` job in `.github/workflows/ci.yml` builds the XCFramework and runs iOS simulator tests, but has several gaps that reduce confidence in the pipeline:
+
+1. **Duplicated wgpu4k build logic** — The 6 steps for cloning, caching, building wgpu4k from source are copy-pasted between the `ci` and `apple` jobs. This is a maintenance burden and makes it easy for the two copies to drift.
+
+2. **Unpinned runner** — `macos-latest` can shift between macOS versions (e.g., 14 to 15) without notice, causing subtle breakage in Xcode/Metal-dependent builds.
+
+3. **No macOS native tests** — All 12 modules declare `macosArm64()` but only iOS simulator tests run in CI. macOS native tests are free to run on the same runner.
+
+4. **Only one XCFramework slice verified** — Only `ios-arm64-simulator` header is checked. The `ios-arm64` device slice could be broken silently.
+
+5. **No artifact upload** — The XCFramework is built and verified but not preserved. Developers can't download it from CI runs.
+
+6. **No xcodebuild verification** — The XCFramework is built but never consumed by the actual Xcode project. A broken import or missing symbol wouldn't be caught.
+
+The solution is straightforward: extract a composite action for wgpu4k, pin the runner, expand tests, verify both slices, upload artifacts, and add xcodegen+xcodebuild.
+
+One consideration: `timeout-minutes` is not supported on composite action steps (GitHub Actions runner limitation), but the job-level timeouts (30min ci, 45min apple) provide the safety net.
+
+For the Rust targets input, the composite action accepts an optional `rust-targets` input. When empty (ci job on Linux), `dtolnay/rust-toolchain` installs just the host target. When populated (apple job), it installs iOS cross-compilation targets.
+
+---
+
+## Plan
+
+### 1. Create composite action `.github/actions/setup-wgpu4k/action.yml`
+
+Encapsulates the duplicated wgpu4k build steps:
+- Extract version/commit from `gradle/libs.versions.toml`
+- Cache `~/.m2/repository/io/ygdrasil` keyed on commit
+- Install Rust (if cache miss), with optional `rust-targets` input
+- Cache Rust toolchain (if cache miss)
+- Build wgpu4k from source (if cache miss)
+- Write build metrics + cache diagnostics to job summary
+
+### 2. Replace wgpu4k steps in both CI jobs
+
+**`ci` job**: Replace 6 steps with single `uses: ./.github/actions/setup-wgpu4k`
+**`apple` job**: Replace 6 steps with `uses: ./.github/actions/setup-wgpu4k` with `rust-targets: aarch64-apple-ios,aarch64-apple-ios-sim`
+
+### 3. Pin macOS runner to `macos-15`
+
+### 4. Add macOS native tests (`macosArm64Test`) alongside iOS simulator tests
+
+### 5. Verify both XCFramework slices (`ios-arm64` and `ios-arm64-simulator`) with summary table
+
+### 6. Upload XCFramework as artifact (14-day retention)
+
+### 7. Add xcodegen + xcodebuild steps to verify end-to-end iOS app build
+
+### Final `apple` job structure
+
+```
+apple:
+  runs-on: macos-15
+  steps:
+    - Checkout
+    - Set up JDK 25
+    - Set up JDK 21
+    - Setup Gradle
+    - Get Kotlin version
+    - Cache Kotlin/Native
+    - Setup wgpu4k (composite action)
+    - Apple native tests + XCFramework
+    - Verify XCFramework exports (both slices)
+    - Upload XCFramework
+    - Generate Xcode project
+    - Build iOS app
+```

--- a/prism-assets/src/iosMain/kotlin/com/hyeonslab/prism/assets/FileReader.ios.kt
+++ b/prism-assets/src/iosMain/kotlin/com/hyeonslab/prism/assets/FileReader.ios.kt
@@ -1,7 +1,0 @@
-package com.hyeonslab.prism.assets
-
-actual object FileReader {
-  actual suspend fun readBytes(path: String): ByteArray {
-    TODO("iOS file reading not yet implemented")
-  }
-}

--- a/prism-assets/src/nativeMain/kotlin/com/hyeonslab/prism/assets/FileReader.native.kt
+++ b/prism-assets/src/nativeMain/kotlin/com/hyeonslab/prism/assets/FileReader.native.kt
@@ -1,0 +1,12 @@
+package com.hyeonslab.prism.assets
+
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readByteArray
+
+actual object FileReader {
+  actual suspend fun readBytes(path: String): ByteArray {
+    return SystemFileSystem.source(Path(path)).buffered().use { it.readByteArray() }
+  }
+}


### PR DESCRIPTION
Harden the Apple CI pipeline with 6 improvements, deduplicate wgpu4k build logic into a reusable composite action, and fix a pre-existing compilation gap in prism-assets.

- Extract wgpu4k build steps into reusable composite action (`.github/actions/setup-wgpu4k`)
- Pin macOS runner from `macos-latest` to `macos-15`
- Add `macosArm64Test` alongside iOS simulator tests
- Verify both XCFramework slices (`ios-arm64` and `ios-arm64-simulator`) with summary table
- Upload XCFramework as CI artifact (14-day retention)
- Add xcodegen + xcodebuild steps to verify end-to-end iOS app build
- Replace `prism-assets` iosMain FileReader TODO stub with `nativeMain` implementation using `kotlinx.io.files.SystemFileSystem` (fixes #22)

## Test plan
- [x] CI `ci` job passes (wgpu4k composite action works on Linux)
- [x] CI `apple` job passes (composite action with `rust-targets` on macOS)
- [x] `macosArm64Test` runs successfully
- [x] Both XCFramework slices verified in summary
- [x] XCFramework artifact uploaded
- [x] xcodegen generates project
- [x] xcodebuild compiles iOS app for simulator