### PR TITLE
ci: add 30-minute timeout to Claude Code Review job

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,6 +19,7 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
The Claude Code Review job has no timeout, so a stall would silently hold a runner for up to 6 hours (GitHub's default). The review of a 45-file PR takes ~15–18 minutes; a 30-minute ceiling gives comfortable headroom while bounding worst-case runner usage.

- Add `timeout-minutes: 30` to the `claude-review` job