### PR TITLE
chore: reduce Gradle cache restore time in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           cache-read-only: false
           add-job-summary: always
+          cache-cleanup: always
 
       - name: Setup wgpu4k
         uses: ./.github/actions/setup-wgpu4k
@@ -57,21 +58,20 @@ jobs:
           echo "### Lint + Test: $((SECONDS - START))s" >> "$GITHUB_STEP_SUMMARY"
           exit ${EXIT:-0}
 
-      - name: Gradle build cache diagnostics
+      - name: Gradle home cache size breakdown
         if: always()
         run: |
-          echo "### Gradle Build Cache" >> "$GITHUB_STEP_SUMMARY"
-          CACHE_DIR=~/.gradle/caches/build-cache-1
-          if [ -d "$CACHE_DIR" ]; then
-            ENTRY_COUNT=$(find "$CACHE_DIR" -type f | wc -l)
-            CACHE_SIZE=$(du -sh "$CACHE_DIR" | cut -f1)
-            echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
-            echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
-            echo "| Entries | ${ENTRY_COUNT} |" >> "$GITHUB_STEP_SUMMARY"
-            echo "| Size | ${CACHE_SIZE} |" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "No local build cache directory found." >> "$GITHUB_STEP_SUMMARY"
-          fi
+          echo "### Gradle Home Cache Size" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Directory | Size |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----------|------|" >> "$GITHUB_STEP_SUMMARY"
+          for D in modules-2 transforms-3 transforms-4 build-cache-1 kotlin-dce; do
+            DIR=~/.gradle/caches/$D
+            if [ -d "$DIR" ]; then
+              SIZE=$(du -sh "$DIR" | cut -f1)
+              echo "| \`caches/$D\` | $SIZE |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+          echo "| **Total ~/.gradle** | $(du -sh ~/.gradle | cut -f1) |" >> "$GITHUB_STEP_SUMMARY"
 
   apple:
     name: Apple Targets
@@ -99,6 +99,10 @@ jobs:
         with:
           cache-read-only: false
           add-job-summary: always
+          cache-cleanup: always
+          gradle-home-cache-excludes: |
+            caches/transforms-*
+            caches/kotlin-dce
 
       - name: Get Kotlin version
         id: kotlin-version
@@ -135,6 +139,21 @@ jobs:
             -Pkotlin.native.parallelThreads=3 || EXIT=$?
           echo "### Apple Tests + XCFrameworks: $((SECONDS - START))s" >> "$GITHUB_STEP_SUMMARY"
           exit ${EXIT:-0}
+
+      - name: Gradle home cache size breakdown
+        if: always()
+        run: |
+          echo "### Gradle Home Cache Size" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Directory | Size |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----------|------|" >> "$GITHUB_STEP_SUMMARY"
+          for D in modules-2 transforms-3 transforms-4 build-cache-1 kotlin-dce; do
+            DIR=~/.gradle/caches/$D
+            if [ -d "$DIR" ]; then
+              SIZE=$(du -sh "$DIR" | cut -f1)
+              echo "| \`caches/$D\` | $SIZE |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+          echo "| **Total ~/.gradle** | $(du -sh ~/.gradle | cut -f1) |" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Verify XCFramework headers
         run: |

--- a/devlog/000019-chore-ci-cache-opt.md
+++ b/devlog/000019-chore-ci-cache-opt.md
@@ -1,0 +1,18 @@
+# 000019 — chore/ci-cache-opt
+
+**Agent:** Claude Sonnet 4.6 (claude-sonnet-4-6) @ prism branch chore/ci-cache-opt
+**Intent:** Reduce Gradle cache restore time in CI (currently ~13 min on the Apple job) by enabling `cache-cleanup: always`, excluding `transforms-*` from the Apple job's cached Gradle home, and adding a per-directory size diagnostic to both jobs' step summaries.
+
+## What Changed
+
+`2026-02-23T...` `.github/workflows/ci.yml` — Added `cache-cleanup: always` to `ci` and `apple` Setup Gradle steps; added `gradle-home-cache-excludes: caches/transforms-* / caches/kotlin-dce` to the `apple` job only; replaced the narrow `build-cache-1`-only diagnostic in `ci` with a broader Gradle Home Cache Size table covering `modules-2`, `transforms-3`, `transforms-4`, `build-cache-1`, and `kotlin-dce`; added the same broad diagnostic to `apple` after its build step.
+
+## Decisions
+
+`2026-02-23T...` Keep `gradle-home-cache-excludes` on Apple only — the Linux `ci` job needs transforms for Android-related detekt/compile tasks.
+`2026-02-23T...` Extend the existing `ci` diagnostic rather than adding a second step, to avoid duplicate GITHUB_STEP_SUMMARY sections.
+`2026-02-23T...` `docker` job left unchanged — it already uses `cache-read-only: true` so it never writes and cleanup is irrelevant.
+
+## Commits
+
+HEAD — chore: reduce Gradle cache restore time in CI

--- a/devlog/plans/000019-01-gradle-cache-restore-time.md
+++ b/devlog/plans/000019-01-gradle-cache-restore-time.md
@@ -1,0 +1,38 @@
+# Plan 000019-01 — Reduce Gradle Cache Restore Time
+
+## Thinking
+
+The Gradle cache restore step takes ~13 minutes in CI, primarily on the Apple (macos-15) runner.
+Root causes:
+1. `cache-cleanup` defaults to `on-success` — stale entries accumulate because cleanup is skipped
+   on failed builds.
+2. The Apple job caches `transforms-*/` (extracted AARs, dexed JARs, derived artifacts) even
+   though it never runs Android tests. These can be hundreds of MB and are regenerated quickly.
+3. No diagnostic exists to measure the `modules-2` vs `transforms-*` split.
+
+Three targeted fixes address all three without changing build semantics:
+
+Fix 1 — `cache-cleanup: always` on both jobs: evicts 7+-day-old entries before saving, even on
+failure. Expected 20–40% reduction over several weeks.
+
+Fix 2 — `gradle-home-cache-excludes` on Apple job only: strips `transforms-*` and `kotlin-dce`
+from the cached archive. Potentially removes 200–800 MB immediately.
+
+Fix 3 — Broader diagnostic step: replaces the existing narrow `build-cache-1` check with a table
+covering `modules-2`, `transforms-3`, `transforms-4`, `build-cache-1`, and `kotlin-dce`, plus a
+total `~/.gradle` size row. Added to both `ci` and `apple` jobs.
+
+The `docker` job already has `cache-read-only: true` — no changes needed there.
+
+## Plan
+
+1. Open `.github/workflows/ci.yml` in the worktree.
+2. **ci job — Setup Gradle step** (line ~37): add `cache-cleanup: always`.
+3. **ci job — Gradle build cache diagnostics step** (line ~60): replace the narrow `build-cache-1`
+   block with the full Gradle Home Cache Size table.
+4. **apple job — Setup Gradle step** (line ~97): add `cache-cleanup: always` and
+   `gradle-home-cache-excludes: caches/transforms-* / caches/kotlin-dce`.
+5. **apple job** — Add a new "Gradle home cache size breakdown" step after the Apple build step
+   (after line ~137, before the Verify XCFramework step).
+6. Run `./gradlew ktfmtCheck detektJvmMain jvmTest` — N/A (pure YAML, no Kotlin changes).
+7. Commit, push, draft PR.


### PR DESCRIPTION
Enable cache-cleanup and add a cache-size diagnostic to the ci and
apple CI jobs to shrink the Gradle home archive that gets saved/restored
on every run.

- Add cache-cleanup: always to the ci and apple Setup Gradle steps so
  Gradle evicts entries unused for 7+ days before saving, even on
  failed builds (previously on-success only)
- Add gradle-home-cache-excludes for caches/transforms-* and
  caches/kotlin-dce on the apple job; these derived artifacts (extracted
  AARs, dexed JARs) are not needed by the macOS runner and can be
  hundreds of MB
- Replace the narrow build-cache-1-only diagnostic in the ci job with
  a full Gradle Home Cache Size table covering modules-2, transforms-3,
  transforms-4, build-cache-1, and kotlin-dce, plus a total ~/.gradle
  row; add the same diagnostic to the apple job after its build step