### PR TITLE
feat: iOS FFI bridge, PrismView apple actual, Compose iOS refactor

### DIFF
--- a/devlog/000020-feat-ios-ffi-bridge-prismview.md
+++ b/devlog/000020-feat-ios-ffi-bridge-prismview.md
@@ -1,0 +1,47 @@
+# 000020 — feat/ios-ffi-bridge-prismview
+
+**Agent:** Claude Sonnet 4.6 (claude-sonnet-4-6) @ prism feat/ios-ffi-bridge-prismview
+**Intent:** Implement iOS FFI bridge in `prism-native`, add `onSurfaceReady` callback to `PrismView`, implement the apple actual (iOS) with UIKitView + MTKView, update Flutter iOS plugin to pass MTKView pointer, and refactor `ComposeIosEntry.kt` to use `PrismView`.
+
+---
+
+## Progress
+
+- [ ] Part 1: iOS FFI bridge (`prism-native/src/iosMain/IosBridge.kt` + build.gradle.kts)
+- [ ] Part 2a: `PrismView` expect + all actuals — add `onSurfaceReady` parameter
+- [ ] Part 2b: `PrismView.ios.kt` — full UIKitView + MTKViewDelegateProtocol implementation
+- [ ] Part 2c: `PrismView.macos.kt` — macOS stub with updated signature
+- [ ] Part 3a: Refactor `ComposeIosEntry.kt` to use `PrismView(onSurfaceReady = ...)`
+- [ ] Part 3b: Update `PrismFlutterPlugin.swift` to pass MTKView pointer
+
+---
+
+## What Changed
+
+_To be filled as work progresses._
+
+---
+
+## Decisions
+
+- `2026-02-23T...` Split `appleMain/PrismView.apple.kt` into `iosMain/PrismView.ios.kt` (full UIKitView implementation) and `macosMain/PrismView.macos.kt` (stub). Having both an `appleMain` actual AND an `iosMain` actual for the same `expect` would cause duplicate-actual compile errors; splitting ensures iOS gets the full impl while macOS keeps the stub.
+- `2026-02-23T...` iOS FFI bridge (`IosBridge.kt`) uses `interpretObjCPointerOrNull<MTKView>` to reconstruct the MTKView from the opaque C pointer, matching the macOS bridge pattern (which uses `NativeAddress(ptr)` for a CAMetalLayer). This is necessary because `iosContextRenderer` takes an `MTKView`, not a raw layer pointer.
+- `2026-02-23T...` Flutter iOS plugin changes to pass MTKView pointer rather than CAMetalLayer pointer so the Kotlin IosBridge can reconstruct the full MTKView object.
+
+---
+
+## Issues
+
+_To be filled if problems arise._
+
+---
+
+## Commits
+
+_To be filled._
+
+---
+
+## Next Steps
+
+_After implementation: run `./gradlew :prism-native:linkDebugSharedIosSimulatorArm64` and `nm -gU ... | grep prism_` to verify FFI symbols._

--- a/devlog/000020-feat-ios-ffi-bridge-prismview.md
+++ b/devlog/000020-feat-ios-ffi-bridge-prismview.md
@@ -29,11 +29,18 @@
 - `2026-02-23T13:07-08:00` `prism-compose/src/wasmJsMain/kotlin/com/hyeonslab/prism/compose/PrismView.wasmJs.kt` — Added `onSurfaceReady` parameter (stub — WASM doesn't call it yet).
 - `2026-02-23T13:07-08:00` `prism-demo-core/src/iosMain/kotlin/com/hyeonslab/prism/demo/ComposeIosEntry.kt` — Refactored from manual `UIKitView + ComposeRenderDelegate` to `PrismView(onSurfaceReady = { ctx, w, h -> ... })`. Scene init in `LaunchedEffect(surfaceCtx)`; per-frame logic via `engineStore.engine.gameLoop.onRender`.
 - `2026-02-23T13:07-08:00` `prism-flutter/flutter_plugin/ios/prism_flutter/Sources/prism_flutter/PrismFlutterPlugin.swift` — Changed from `CAMetalLayer` sublayer to embedded `MTKView` subview; passes `Unmanaged.passUnretained(mtkView).toOpaque()` pointer to `prism_attach_metal_layer`.
+- `2026-02-23T13:07-08:00` `prism-core/src/commonMain/kotlin/com/hyeonslab/prism/core/GameLoop.kt` — Added single-fire `onStop` callback invoked at the start of `stop()`, cleared immediately after firing.
+- `2026-02-23T13:07-08:00` `prism-demo-core/src/iosMain/kotlin/com/hyeonslab/prism/demo/ComposeIosEntry.kt` (post-review) — Disposal ordering fix via `gameLoop.onStop`; `rememberCoroutineScope()` for progressive texture scope; `LaunchedEffect` for camera aspect ratio update on resize.
+- `2026-02-23T13:07-08:00` `prism-native/src/iosMain/kotlin/engine/prism/native/IosBridge.kt` (post-review) — Map insert before `startExternal()`; UNUSED_PARAMETER comment; `getAndUpdate` in `prismDetachSurface`.
+- `2026-02-23T13:07-08:00` `prism-native/src/macosMain/kotlin/engine/prism/native/MacosBridge.kt` (post-review) — Map insert before `startExternal()`; `getAndUpdate` in `prismDetachSurface`.
+- `2026-02-23T13:07-08:00` `prism-flutter/flutter_plugin/ios/prism_flutter/Sources/prism_flutter/PrismFlutterPlugin.swift` (post-review) — Replace deprecated `UIScreen.main.scale` with `(window?.screen ?? UIScreen.main).scale`.
 
 ---
 
 ## Decisions
 
+- `2026-02-23T13:07-08:00` `GameLoop.onStop` chosen over `PrismView(onBeforeDetach = ...)` API change: hooking cleanup into `stop()` gives correct ordering (before `prismSurface.detach()`) without adding a parameter to `PrismView`'s cross-platform expect signature.
+- `2026-02-23T13:07-08:00` `rememberCoroutineScope()` for progressive texture scope: ties scope lifetime to the composition instead of a manually-managed `CoroutineScope` inside a `LaunchedEffect` that could outlive the composable.
 - `2026-02-23T13:07-08:00` Split `appleMain/PrismView.apple.kt` into `iosMain/PrismView.ios.kt` (full UIKitView implementation) and `macosMain/PrismView.macos.kt` (stub). Having both an `appleMain` actual AND an `iosMain` actual for the same `expect` would cause duplicate-actual compile errors; splitting ensures iOS gets the full impl while macOS keeps the stub.
 - `2026-02-23T13:07-08:00` iOS FFI bridge (`IosBridge.kt`) uses `interpretObjCPointerOrNull<MTKView>` to reconstruct the MTKView from the opaque C pointer, matching the macOS bridge pattern (which uses `NativeAddress(ptr)` for a CAMetalLayer). This is necessary because `iosContextRenderer` takes an `MTKView`, not a raw layer pointer.
 - `2026-02-23T13:07-08:00` Flutter iOS plugin changes to pass MTKView pointer rather than CAMetalLayer pointer so the Kotlin IosBridge can reconstruct the full MTKView object.
@@ -50,7 +57,9 @@
 
 - 8a999d0b — chore: add devlog and plan for ios-ffi-bridge-prismview
 - edb8f07 — feat: iOS FFI bridge, PrismView onSurfaceReady, Compose iOS refactor
-- HEAD — chore: update devlog with real timestamps and commit hashes
+- dbe482a — chore: update devlog with real timestamps and commit hashes
+- 8eb7879 — chore: fix devlog commits section — leave HEAD as HEAD
+- HEAD — fix: address post-review issues in iOS FFI bridge and Compose entry
 
 ---
 

--- a/devlog/000020-feat-ios-ffi-bridge-prismview.md
+++ b/devlog/000020-feat-ios-ffi-bridge-prismview.md
@@ -18,36 +18,37 @@
 
 ## What Changed
 
-- `2026-02-23T00:00-08:00` `prism-native/build.gradle.kts` — Added `iosMain.dependencies { wgpu4k.toolkit + coroutines }` inside `if (isMac)` block; also added `iosArm64()` + `iosSimulatorArm64()` already present via `if (isMac)` targets.
-- `2026-02-23T00:00-08:00` `prism-native/src/iosMain/kotlin/engine/prism/native/IosBridge.kt` — **NEW** iOS FFI bridge exporting `prism_attach_metal_layer`, `prism_render_frame`, `prism_resize`, `prism_detach_surface` via `@CName`. Uses `interpretObjCPointerOrNull<MTKView>` to reconstruct the MTKView from opaque C pointer, then `iosContextRenderer(mtkView, w, h)` to create a wgpu `IosContext`. Clear-color render pass per frame.
-- `2026-02-23T00:00-08:00` `prism-compose/src/nonNativeMain/kotlin/com/hyeonslab/prism/compose/PrismView.kt` — Added `onSurfaceReady: ((WGPUContext, Int, Int) -> Unit)? = null` parameter to `expect fun PrismView`.
-- `2026-02-23T00:00-08:00` `prism-compose/src/appleMain/kotlin/com/hyeonslab/prism/compose/PrismView.apple.kt` — Removed `actual` declaration; now empty (actuals moved to iosMain + macosMain).
-- `2026-02-23T00:00-08:00` `prism-compose/src/iosMain/kotlin/com/hyeonslab/prism/compose/PrismView.ios.kt` — **NEW** Full iOS actual: `UIKitView(MTKView)` + `MTKViewDelegateProtocol` drives `gameLoop.tick()`, calls `onSurfaceReady` once after surface init, dispatches `FrameTick` + `SurfaceResized` events on main queue.
-- `2026-02-23T00:00-08:00` `prism-compose/src/macosMain/kotlin/com/hyeonslab/prism/compose/PrismView.macos.kt` — **NEW** macOS stub actual; logs warning, no-op (macOS Compose/Metal not yet implemented).
-- `2026-02-23T00:00-08:00` `prism-compose/src/jvmMain/kotlin/com/hyeonslab/prism/compose/PrismView.jvm.kt` — Added `onSurfaceReady` parameter; invoked after JVM surface is configured.
-- `2026-02-23T00:00-08:00` `prism-compose/src/androidMain/kotlin/com/hyeonslab/prism/compose/PrismView.android.kt` — Added `onSurfaceReady` parameter; invoked after Android surface and wgpu context are ready.
-- `2026-02-23T00:00-08:00` `prism-compose/src/wasmJsMain/kotlin/com/hyeonslab/prism/compose/PrismView.wasmJs.kt` — Added `onSurfaceReady` parameter (stub — WASM doesn't call it yet).
-- `2026-02-23T00:00-08:00` `prism-demo-core/src/iosMain/kotlin/com/hyeonslab/prism/demo/ComposeIosEntry.kt` — Refactored from manual `UIKitView + ComposeRenderDelegate` to `PrismView(onSurfaceReady = { ctx, w, h -> ... })`. Scene init in `LaunchedEffect(surfaceCtx)`; per-frame logic via `engineStore.engine.gameLoop.onRender`.
-- `2026-02-23T00:00-08:00` `prism-flutter/flutter_plugin/ios/prism_flutter/Sources/prism_flutter/PrismFlutterPlugin.swift` — Changed from `CAMetalLayer` sublayer to embedded `MTKView` subview; passes `Unmanaged.passUnretained(mtkView).toOpaque()` pointer to `prism_attach_metal_layer`.
+- `2026-02-23T13:07-08:00` `prism-native/build.gradle.kts` — Added `iosMain.dependencies { wgpu4k.toolkit + coroutines }` inside `if (isMac)` block; also added `iosArm64()` + `iosSimulatorArm64()` already present via `if (isMac)` targets.
+- `2026-02-23T13:07-08:00` `prism-native/src/iosMain/kotlin/engine/prism/native/IosBridge.kt` — **NEW** iOS FFI bridge exporting `prism_attach_metal_layer`, `prism_render_frame`, `prism_resize`, `prism_detach_surface` via `@CName`. Uses `interpretObjCPointerOrNull<MTKView>` to reconstruct the MTKView from opaque C pointer, then `iosContextRenderer(mtkView, w, h)` to create a wgpu `IosContext`. Clear-color render pass per frame.
+- `2026-02-23T13:07-08:00` `prism-compose/src/nonNativeMain/kotlin/com/hyeonslab/prism/compose/PrismView.kt` — Added `onSurfaceReady: ((WGPUContext, Int, Int) -> Unit)? = null` parameter to `expect fun PrismView`.
+- `2026-02-23T13:07-08:00` `prism-compose/src/appleMain/kotlin/com/hyeonslab/prism/compose/PrismView.apple.kt` — Removed `actual` declaration; now empty (actuals moved to iosMain + macosMain).
+- `2026-02-23T13:07-08:00` `prism-compose/src/iosMain/kotlin/com/hyeonslab/prism/compose/PrismView.ios.kt` — **NEW** Full iOS actual: `UIKitView(MTKView)` + `MTKViewDelegateProtocol` drives `gameLoop.tick()`, calls `onSurfaceReady` once after surface init, dispatches `FrameTick` + `SurfaceResized` events on main queue.
+- `2026-02-23T13:07-08:00` `prism-compose/src/macosMain/kotlin/com/hyeonslab/prism/compose/PrismView.macos.kt` — **NEW** macOS stub actual; logs warning, no-op (macOS Compose/Metal not yet implemented).
+- `2026-02-23T13:07-08:00` `prism-compose/src/jvmMain/kotlin/com/hyeonslab/prism/compose/PrismView.jvm.kt` — Added `onSurfaceReady` parameter; invoked after JVM surface is configured.
+- `2026-02-23T13:07-08:00` `prism-compose/src/androidMain/kotlin/com/hyeonslab/prism/compose/PrismView.android.kt` — Added `onSurfaceReady` parameter; invoked after Android surface and wgpu context are ready.
+- `2026-02-23T13:07-08:00` `prism-compose/src/wasmJsMain/kotlin/com/hyeonslab/prism/compose/PrismView.wasmJs.kt` — Added `onSurfaceReady` parameter (stub — WASM doesn't call it yet).
+- `2026-02-23T13:07-08:00` `prism-demo-core/src/iosMain/kotlin/com/hyeonslab/prism/demo/ComposeIosEntry.kt` — Refactored from manual `UIKitView + ComposeRenderDelegate` to `PrismView(onSurfaceReady = { ctx, w, h -> ... })`. Scene init in `LaunchedEffect(surfaceCtx)`; per-frame logic via `engineStore.engine.gameLoop.onRender`.
+- `2026-02-23T13:07-08:00` `prism-flutter/flutter_plugin/ios/prism_flutter/Sources/prism_flutter/PrismFlutterPlugin.swift` — Changed from `CAMetalLayer` sublayer to embedded `MTKView` subview; passes `Unmanaged.passUnretained(mtkView).toOpaque()` pointer to `prism_attach_metal_layer`.
 
 ---
 
 ## Decisions
 
-- `2026-02-23T...` Split `appleMain/PrismView.apple.kt` into `iosMain/PrismView.ios.kt` (full UIKitView implementation) and `macosMain/PrismView.macos.kt` (stub). Having both an `appleMain` actual AND an `iosMain` actual for the same `expect` would cause duplicate-actual compile errors; splitting ensures iOS gets the full impl while macOS keeps the stub.
-- `2026-02-23T...` iOS FFI bridge (`IosBridge.kt`) uses `interpretObjCPointerOrNull<MTKView>` to reconstruct the MTKView from the opaque C pointer, matching the macOS bridge pattern (which uses `NativeAddress(ptr)` for a CAMetalLayer). This is necessary because `iosContextRenderer` takes an `MTKView`, not a raw layer pointer.
-- `2026-02-23T...` Flutter iOS plugin changes to pass MTKView pointer rather than CAMetalLayer pointer so the Kotlin IosBridge can reconstruct the full MTKView object.
+- `2026-02-23T13:07-08:00` Split `appleMain/PrismView.apple.kt` into `iosMain/PrismView.ios.kt` (full UIKitView implementation) and `macosMain/PrismView.macos.kt` (stub). Having both an `appleMain` actual AND an `iosMain` actual for the same `expect` would cause duplicate-actual compile errors; splitting ensures iOS gets the full impl while macOS keeps the stub.
+- `2026-02-23T13:07-08:00` iOS FFI bridge (`IosBridge.kt`) uses `interpretObjCPointerOrNull<MTKView>` to reconstruct the MTKView from the opaque C pointer, matching the macOS bridge pattern (which uses `NativeAddress(ptr)` for a CAMetalLayer). This is necessary because `iosContextRenderer` takes an `MTKView`, not a raw layer pointer.
+- `2026-02-23T13:07-08:00` Flutter iOS plugin changes to pass MTKView pointer rather than CAMetalLayer pointer so the Kotlin IosBridge can reconstruct the full MTKView object.
 
 ---
 
 ## Issues
 
-- `2026-02-23T00:00-08:00` **`val iosMain by getting` fails in `prism-native/build.gradle.kts`** — `prism-native` does not call `applyDefaultHierarchyTemplate()`, so the `by getting` delegate syntax throws "KotlinSourceSet with name 'iosMain' not found" at configuration time. Fix: use property-style `iosMain.dependencies { ... }` which matches how `macosMain.dependencies { ... }` is accessed in the same file.
+- `2026-02-23T13:07-08:00` **`val iosMain by getting` fails in `prism-native/build.gradle.kts`** — `prism-native` does not call `applyDefaultHierarchyTemplate()`, so the `by getting` delegate syntax throws "KotlinSourceSet with name 'iosMain' not found" at configuration time. Fix: use property-style `iosMain.dependencies { ... }` which matches how `macosMain.dependencies { ... }` is accessed in the same file.
 
 ---
 
 ## Commits
 
+- 8a999d0b — chore: add devlog and plan for ios-ffi-bridge-prismview
 - HEAD — feat: iOS FFI bridge, PrismView onSurfaceReady, Compose iOS refactor
 
 ---

--- a/devlog/000020-feat-ios-ffi-bridge-prismview.md
+++ b/devlog/000020-feat-ios-ffi-bridge-prismview.md
@@ -34,6 +34,8 @@
 - `2026-02-23T13:07-08:00` `prism-native/src/iosMain/kotlin/engine/prism/native/IosBridge.kt` (post-review) — Map insert before `startExternal()`; UNUSED_PARAMETER comment; `getAndUpdate` in `prismDetachSurface`.
 - `2026-02-23T13:07-08:00` `prism-native/src/macosMain/kotlin/engine/prism/native/MacosBridge.kt` (post-review) — Map insert before `startExternal()`; `getAndUpdate` in `prismDetachSurface`.
 - `2026-02-23T13:07-08:00` `prism-flutter/flutter_plugin/ios/prism_flutter/Sources/prism_flutter/PrismFlutterPlugin.swift` (post-review) — Replace deprecated `UIScreen.main.scale` with `(window?.screen ?? UIScreen.main).scale`.
+- `2026-02-23T13:07-08:00` `prism-flutter/flutter_plugin/ios/prism_flutter/Sources/prism_flutter/PrismFlutterPlugin.swift` (post-review-2) — Fix Swift compile error introduced by `replace_all` in previous pass: `setupMtkView()` is on `NSObject` (no `window` property); replaced bare `window` with `_view.window?.screen?.scale ?? UIScreen.main.scale`. `layoutSubviews()` on `PrismMetalView: UIView` is unaffected and keeps `(window?.screen ?? UIScreen.main).scale`.
+- `2026-02-23T13:07-08:00` `prism-core/src/commonMain/kotlin/com/hyeonslab/prism/core/GameLoop.kt` (post-review-2) — Added `if (!isRunning) return` guard at top of `stop()` to prevent `onStop` from firing on a loop that was never started.
 
 ---
 
@@ -50,6 +52,7 @@
 ## Issues
 
 - `2026-02-23T13:07-08:00` **`val iosMain by getting` fails in `prism-native/build.gradle.kts`** — `prism-native` does not call `applyDefaultHierarchyTemplate()`, so the `by getting` delegate syntax throws "KotlinSourceSet with name 'iosMain' not found" at configuration time. Fix: use property-style `iosMain.dependencies { ... }` which matches how `macosMain.dependencies { ... }` is accessed in the same file.
+- `2026-02-23T13:07-08:00` **`replace_all: true` applied Swift scale fix to NSObject context** — Used `replace_all: true` to replace `UIScreen.main.scale` in `PrismFlutterPlugin.swift`. Both occurrences were replaced identically, but `setupMtkView()` lives on `PrismIOSPlatformView: NSObject` which has no `window` property — Swift compile error. `layoutSubviews()` lives on `PrismMetalView: UIView` where `window` is valid. Fixed in subsequent pass by using `_view.window?.screen?.scale ?? UIScreen.main.scale` in `setupMtkView()`.
 
 ---
 
@@ -59,6 +62,7 @@
 - edb8f07 — feat: iOS FFI bridge, PrismView onSurfaceReady, Compose iOS refactor
 - dbe482a — chore: update devlog with real timestamps and commit hashes
 - 8eb7879 — chore: fix devlog commits section — leave HEAD as HEAD
+- 4a46d82 — fix: address post-review issues in iOS FFI bridge and Compose entry
 - HEAD — fix: address post-review issues in iOS FFI bridge and Compose entry
 
 ---

--- a/devlog/000020-feat-ios-ffi-bridge-prismview.md
+++ b/devlog/000020-feat-ios-ffi-bridge-prismview.md
@@ -36,6 +36,7 @@
 - `2026-02-23T13:07-08:00` `prism-flutter/flutter_plugin/ios/prism_flutter/Sources/prism_flutter/PrismFlutterPlugin.swift` (post-review) — Replace deprecated `UIScreen.main.scale` with `(window?.screen ?? UIScreen.main).scale`.
 - `2026-02-23T13:07-08:00` `prism-flutter/flutter_plugin/ios/prism_flutter/Sources/prism_flutter/PrismFlutterPlugin.swift` (post-review-2) — Fix Swift compile error introduced by `replace_all` in previous pass: `setupMtkView()` is on `NSObject` (no `window` property); replaced bare `window` with `_view.window?.screen?.scale ?? UIScreen.main.scale`. `layoutSubviews()` on `PrismMetalView: UIView` is unaffected and keeps `(window?.screen ?? UIScreen.main).scale`.
 - `2026-02-23T13:07-08:00` `prism-core/src/commonMain/kotlin/com/hyeonslab/prism/core/GameLoop.kt` (post-review-2) — Added `if (!isRunning) return` guard at top of `stop()` to prevent `onStop` from firing on a loop that was never started.
+- `2026-02-23T18:15-08:00` `prism-compose/src/iosMain/kotlin/com/hyeonslab/prism/compose/PrismView.ios.kt` (CI fix) — Changed `width.toInt()` → `this.width.toInt()` and `height.toInt()` → `this.height.toInt()` inside the `mtkView(drawableSizeWillChange:)` delegate's `useContents { }` lambda to fix `REDUNDANT_CALL_OF_CONVERSION_METHOD` compiler error (allWarningsAsErrors).
 
 ---
 
@@ -53,6 +54,7 @@
 
 - `2026-02-23T13:07-08:00` **`val iosMain by getting` fails in `prism-native/build.gradle.kts`** — `prism-native` does not call `applyDefaultHierarchyTemplate()`, so the `by getting` delegate syntax throws "KotlinSourceSet with name 'iosMain' not found" at configuration time. Fix: use property-style `iosMain.dependencies { ... }` which matches how `macosMain.dependencies { ... }` is accessed in the same file.
 - `2026-02-23T13:07-08:00` **`replace_all: true` applied Swift scale fix to NSObject context** — Used `replace_all: true` to replace `UIScreen.main.scale` in `PrismFlutterPlugin.swift`. Both occurrences were replaced identically, but `setupMtkView()` lives on `PrismIOSPlatformView: NSObject` which has no `window` property — Swift compile error. `layoutSubviews()` lives on `PrismMetalView: UIView` where `window` is valid. Fixed in subsequent pass by using `_view.window?.screen?.scale ?? UIScreen.main.scale` in `setupMtkView()`.
+- `2026-02-23T18:15-08:00` **`REDUNDANT_CALL_OF_CONVERSION_METHOD` in `useContents` lambda** — CI failed on `compileKotlinIosSimulatorArm64` due to `width.toInt()` / `height.toInt()` being flagged as redundant in the `mtkView(drawableSizeWillChange:)` delegate. Root cause: inside `drawableSizeWillChange.useContents { }`, Kotlin's name resolution picks up the outer captured `var width: Int` / `var height: Int` (declared earlier in the same `LaunchedEffect` scope) rather than `CGSize.width/height` (the lambda receiver's members). Calling `.toInt()` on an already-`Int` is the redundant conversion. Fix: use explicit `this.width` / `this.height` to force resolution to the `CGSize` receiver fields (type `Double`).
 
 ---
 
@@ -63,7 +65,9 @@
 - dbe482a — chore: update devlog with real timestamps and commit hashes
 - 8eb7879 — chore: fix devlog commits section — leave HEAD as HEAD
 - 4a46d82 — fix: address post-review issues in iOS FFI bridge and Compose entry
-- HEAD — fix: address post-review issues in iOS FFI bridge and Compose entry
+- de75f6d — fix: address post-review issues in iOS FFI bridge and Compose entry
+- 4b97440 — chore: update devlog with post-review-2 fixes
+- HEAD — fix: use explicit this.width/height in useContents to avoid REDUNDANT_CALL_OF_CONVERSION_METHOD
 
 ---
 

--- a/devlog/000020-feat-ios-ffi-bridge-prismview.md
+++ b/devlog/000020-feat-ios-ffi-bridge-prismview.md
@@ -49,7 +49,8 @@
 ## Commits
 
 - 8a999d0b — chore: add devlog and plan for ios-ffi-bridge-prismview
-- HEAD — feat: iOS FFI bridge, PrismView onSurfaceReady, Compose iOS refactor
+- edb8f07 — feat: iOS FFI bridge, PrismView onSurfaceReady, Compose iOS refactor
+- HEAD — chore: update devlog with real timestamps and commit hashes
 
 ---
 

--- a/devlog/000020-feat-ios-ffi-bridge-prismview.md
+++ b/devlog/000020-feat-ios-ffi-bridge-prismview.md
@@ -7,18 +7,28 @@
 
 ## Progress
 
-- [ ] Part 1: iOS FFI bridge (`prism-native/src/iosMain/IosBridge.kt` + build.gradle.kts)
-- [ ] Part 2a: `PrismView` expect + all actuals — add `onSurfaceReady` parameter
-- [ ] Part 2b: `PrismView.ios.kt` — full UIKitView + MTKViewDelegateProtocol implementation
-- [ ] Part 2c: `PrismView.macos.kt` — macOS stub with updated signature
-- [ ] Part 3a: Refactor `ComposeIosEntry.kt` to use `PrismView(onSurfaceReady = ...)`
-- [ ] Part 3b: Update `PrismFlutterPlugin.swift` to pass MTKView pointer
+- [x] Part 1: iOS FFI bridge (`prism-native/src/iosMain/IosBridge.kt` + build.gradle.kts)
+- [x] Part 2a: `PrismView` expect + all actuals — add `onSurfaceReady` parameter
+- [x] Part 2b: `PrismView.ios.kt` — full UIKitView + MTKViewDelegateProtocol implementation
+- [x] Part 2c: `PrismView.macos.kt` — macOS stub with updated signature
+- [x] Part 3a: Refactor `ComposeIosEntry.kt` to use `PrismView(onSurfaceReady = ...)`
+- [x] Part 3b: Update `PrismFlutterPlugin.swift` to pass MTKView pointer
 
 ---
 
 ## What Changed
 
-_To be filled as work progresses._
+- `2026-02-23T00:00-08:00` `prism-native/build.gradle.kts` — Added `iosMain.dependencies { wgpu4k.toolkit + coroutines }` inside `if (isMac)` block; also added `iosArm64()` + `iosSimulatorArm64()` already present via `if (isMac)` targets.
+- `2026-02-23T00:00-08:00` `prism-native/src/iosMain/kotlin/engine/prism/native/IosBridge.kt` — **NEW** iOS FFI bridge exporting `prism_attach_metal_layer`, `prism_render_frame`, `prism_resize`, `prism_detach_surface` via `@CName`. Uses `interpretObjCPointerOrNull<MTKView>` to reconstruct the MTKView from opaque C pointer, then `iosContextRenderer(mtkView, w, h)` to create a wgpu `IosContext`. Clear-color render pass per frame.
+- `2026-02-23T00:00-08:00` `prism-compose/src/nonNativeMain/kotlin/com/hyeonslab/prism/compose/PrismView.kt` — Added `onSurfaceReady: ((WGPUContext, Int, Int) -> Unit)? = null` parameter to `expect fun PrismView`.
+- `2026-02-23T00:00-08:00` `prism-compose/src/appleMain/kotlin/com/hyeonslab/prism/compose/PrismView.apple.kt` — Removed `actual` declaration; now empty (actuals moved to iosMain + macosMain).
+- `2026-02-23T00:00-08:00` `prism-compose/src/iosMain/kotlin/com/hyeonslab/prism/compose/PrismView.ios.kt` — **NEW** Full iOS actual: `UIKitView(MTKView)` + `MTKViewDelegateProtocol` drives `gameLoop.tick()`, calls `onSurfaceReady` once after surface init, dispatches `FrameTick` + `SurfaceResized` events on main queue.
+- `2026-02-23T00:00-08:00` `prism-compose/src/macosMain/kotlin/com/hyeonslab/prism/compose/PrismView.macos.kt` — **NEW** macOS stub actual; logs warning, no-op (macOS Compose/Metal not yet implemented).
+- `2026-02-23T00:00-08:00` `prism-compose/src/jvmMain/kotlin/com/hyeonslab/prism/compose/PrismView.jvm.kt` — Added `onSurfaceReady` parameter; invoked after JVM surface is configured.
+- `2026-02-23T00:00-08:00` `prism-compose/src/androidMain/kotlin/com/hyeonslab/prism/compose/PrismView.android.kt` — Added `onSurfaceReady` parameter; invoked after Android surface and wgpu context are ready.
+- `2026-02-23T00:00-08:00` `prism-compose/src/wasmJsMain/kotlin/com/hyeonslab/prism/compose/PrismView.wasmJs.kt` — Added `onSurfaceReady` parameter (stub — WASM doesn't call it yet).
+- `2026-02-23T00:00-08:00` `prism-demo-core/src/iosMain/kotlin/com/hyeonslab/prism/demo/ComposeIosEntry.kt` — Refactored from manual `UIKitView + ComposeRenderDelegate` to `PrismView(onSurfaceReady = { ctx, w, h -> ... })`. Scene init in `LaunchedEffect(surfaceCtx)`; per-frame logic via `engineStore.engine.gameLoop.onRender`.
+- `2026-02-23T00:00-08:00` `prism-flutter/flutter_plugin/ios/prism_flutter/Sources/prism_flutter/PrismFlutterPlugin.swift` — Changed from `CAMetalLayer` sublayer to embedded `MTKView` subview; passes `Unmanaged.passUnretained(mtkView).toOpaque()` pointer to `prism_attach_metal_layer`.
 
 ---
 
@@ -32,13 +42,13 @@ _To be filled as work progresses._
 
 ## Issues
 
-_To be filled if problems arise._
+- `2026-02-23T00:00-08:00` **`val iosMain by getting` fails in `prism-native/build.gradle.kts`** — `prism-native` does not call `applyDefaultHierarchyTemplate()`, so the `by getting` delegate syntax throws "KotlinSourceSet with name 'iosMain' not found" at configuration time. Fix: use property-style `iosMain.dependencies { ... }` which matches how `macosMain.dependencies { ... }` is accessed in the same file.
 
 ---
 
 ## Commits
 
-_To be filled._
+- HEAD — feat: iOS FFI bridge, PrismView onSurfaceReady, Compose iOS refactor
 
 ---
 

--- a/devlog/plans/000020-01-ios-ffi-bridge-prismview.md
+++ b/devlog/plans/000020-01-ios-ffi-bridge-prismview.md
@@ -1,0 +1,56 @@
+# 000020-01 — iOS FFI Bridge + PrismView.apple.kt + Compose Tab Refactor
+
+## Thinking
+
+The plan has three interconnected parts:
+
+**Part 1 (prism-native IosBridge):** macOS already has `MacosBridge.kt` with 4 `@CName` exported C functions using `macosContextRendererFromLayer(NativeAddress(ptr), ...)`. iOS needs the same 4 symbols but using `iosContextRenderer(mtkView, ...)`. The key difference is the API expects an `MTKView` object (not a raw layer pointer). We reconstruct the `MTKView` from the opaque C pointer via `interpretObjCPointerOrNull<MTKView>(ptr.rawValue)`. The Flutter Swift plugin currently passes a `CAMetalLayer` pointer — this must change to an MTKView pointer.
+
+**Part 2 (PrismView):** The current `PrismView.apple.kt` is a shared stub for all Apple platforms (iOS + macOS). The new iOS implementation uses `UIKitView` from `androidx.compose.ui.interop`, which is iOS-only and not available in macOS Compose. Therefore, we MUST split the single `appleMain` actual into separate `iosMain` and `macosMain` actuals — having both would cause duplicate-actual compile errors. The `expect` signature gains `onSurfaceReady: ((WGPUContext, Int, Int) -> Unit)? = null`. `WGPUContext` is available in `nonNativeMain` via `prism-renderer → wgpu4k` (which is in wgpu4k's commonMain).
+
+**Part 3 (ComposeIosEntry refactor):** Instead of manually managing UIKitView + MTKView lifecycle with `ComposeRenderDelegate`, we delegate to `PrismView`. The `DemoScene` initialization and per-frame logic wire into `engineStore.engine.gameLoop.onRender`. The `DemoScene.shutdown()` call is replaced by just `scene.world.shutdown()` to avoid calling `engine.shutdown()` on the wrong engine.
+
+Key source-set change: `appleMain/PrismView.apple.kt` loses its `actual fun PrismView` (becomes empty/package-only), replaced by `iosMain/PrismView.ios.kt` and `macosMain/PrismView.macos.kt`.
+
+## Plan
+
+1. **prism-native/build.gradle.kts** — Add `iosMain` source set (inside `if (isMac)`) with `wgpu4k.toolkit` + `kotlinx.coroutines.core` dependencies.
+
+2. **prism-native/src/iosMain/.../IosBridge.kt** — Create new file. Near-copy of `MacosBridge.kt` with:
+   - `IosContext` instead of `MacosContext`
+   - `iosSurfaces: AtomicRef<Map<Long, IosContext>>` atomic map
+   - `iosContextRenderer(mtkView, width, height)` call
+   - MTKView reconstructed via `interpretObjCPointerOrNull<MTKView>(ptr.rawValue)`
+   - Same 4 `@CName` exported functions
+
+3. **prism-flutter/...PrismFlutterPlugin.swift** — In `PrismMetalView`: replace `metalLayer: CAMetalLayer?` with `mtkView: MTKView?`. Rename `setupMetalLayer()` → `setupMtkView()`. Pass MTKView pointer via `Unmanaged.passUnretained(mtkView).toOpaque()`. Update `layoutSubviews()` to resize `mtkView.frame` (not metalLayer.frame). Add `import MetalKit` at top.
+
+4. **prism-compose/src/nonNativeMain/.../PrismView.kt** — Add `onSurfaceReady: ((WGPUContext, Int, Int) -> Unit)? = null` to `expect fun PrismView`. Update docstring.
+
+5. **prism-compose/src/appleMain/.../PrismView.apple.kt** — Remove `actual fun PrismView` (keep only package declaration). The actuals move to iosMain and macosMain.
+
+6. **prism-compose/src/iosMain/.../PrismView.ios.kt** — NEW file. Full implementation:
+   - `UIKitView` holding an `MTKView`
+   - `LaunchedEffect(mtkView)` creates surface via `createPrismSurface(view, w, h)`
+   - After surface ready: dispatch `SurfaceResized`, call `onSurfaceReady`, start game loop
+   - `MTKViewDelegateProtocol` delegate ticks `engine.gameLoop.tick()` per frame
+   - Delegate dispatches FPS via `NSOperationQueue.mainQueue`
+   - Strong ref to delegate stored in remembered state var (weak MTKView.delegate)
+   - `DisposableEffect` cleans up: null delegate, stop game loop, detach surface
+
+7. **prism-compose/src/macosMain/.../PrismView.macos.kt** — NEW file. Updated stub with new signature (same log warning, onDispose = {}).
+
+8. **prism-compose/src/jvmMain/.../PrismView.jvm.kt** — Add `onSurfaceReady` parameter. Currently uses `SwingPanel(PrismPanel)` — `onSurfaceReady` is invoked from `p.onReady` callback after the panel's wgpu context is ready.
+
+9. **prism-compose/src/androidMain/.../PrismView.android.kt** — Add `onSurfaceReady` parameter. Invoke it after `createPrismSurface` + guard checks succeed.
+
+10. **prism-compose/src/wasmJsMain/.../PrismView.wasmJs.kt** — Add `onSurfaceReady` parameter (no-op in stub).
+
+11. **prism-demo-core/src/iosMain/.../ComposeIosEntry.kt** — Refactor:
+    - Replace manual `UIKitView(factory=MTKView)` + `ComposeRenderDelegate` with `PrismView`
+    - `val engineStore = rememberEngineStore(EngineConfig("Prism iOS Compose"))`
+    - `PrismView(store = engineStore, modifier = Modifier.fillMaxSize(), onSurfaceReady = { ctx, w, h -> ... })`
+    - In onSurfaceReady: create scene, set `engineStore.engine.gameLoop.onRender`
+    - `DisposableEffect` to clear onRender + `scene.world.shutdown()`
+    - Remove `ComposeRenderDelegate` class entirely
+    - Keep DemoStore / overlay UI unchanged

--- a/prism-compose/src/androidMain/kotlin/com/hyeonslab/prism/compose/PrismView.android.kt
+++ b/prism-compose/src/androidMain/kotlin/com/hyeonslab/prism/compose/PrismView.android.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import co.touchlab.kermit.Logger
 import com.hyeonslab.prism.widget.PrismSurface
 import com.hyeonslab.prism.widget.createPrismSurface
+import io.ygdrasil.webgpu.WGPUContext
 
 private val log = Logger.withTag("PrismView.Android")
 
@@ -27,7 +28,11 @@ private val log = Logger.withTag("PrismView.Android")
  * [EngineStateEvent]s through [EngineStore.dispatch].
  */
 @Composable
-actual fun PrismView(store: EngineStore, modifier: Modifier) {
+actual fun PrismView(
+  store: EngineStore,
+  modifier: Modifier,
+  onSurfaceReady: ((WGPUContext, Int, Int) -> Unit)?,
+) {
   // Track the current SurfaceHolder identity separately from dimensions so that a resize
   // on the same holder dispatches SurfaceResized without recreating the wgpu surface.
   var currentHolder by remember { mutableStateOf<SurfaceHolder?>(null) }
@@ -114,6 +119,10 @@ actual fun PrismView(store: EngineStore, modifier: Modifier) {
       }
       prismSurface = surface
       store.dispatch(EngineStateEvent.SurfaceResized(width, height))
+      val wgpuCtx = surface.wgpuContext
+      if (wgpuCtx != null) {
+        onSurfaceReady?.invoke(wgpuCtx, width, height)
+      }
       renderingActive = true
       log.i { "PrismSurface ready" }
     } catch (e: Exception) {

--- a/prism-compose/src/appleMain/kotlin/com/hyeonslab/prism/compose/PrismView.apple.kt
+++ b/prism-compose/src/appleMain/kotlin/com/hyeonslab/prism/compose/PrismView.apple.kt
@@ -1,17 +1,3 @@
+// Intentionally empty — PrismView actuals are provided by iosMain and macosMain.
+// This file exists to satisfy the Kotlin source layout convention for appleMain.
 package com.hyeonslab.prism.compose
-
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Modifier
-import co.touchlab.kermit.Logger
-
-private val log = Logger.withTag("PrismView.Apple")
-
-@Composable
-actual fun PrismView(store: EngineStore, modifier: Modifier) {
-  LaunchedEffect(Unit) {
-    log.w { "PrismView Apple stub \u2014 native Metal integration not yet implemented" }
-  }
-  DisposableEffect(store) { onDispose {} }
-}

--- a/prism-compose/src/iosMain/kotlin/com/hyeonslab/prism/compose/PrismView.ios.kt
+++ b/prism-compose/src/iosMain/kotlin/com/hyeonslab/prism/compose/PrismView.ios.kt
@@ -98,8 +98,8 @@ actual fun PrismView(
 
           override fun mtkView(view: MTKView, drawableSizeWillChange: CValue<CGSize>) {
             drawableSizeWillChange.useContents {
-              val w = width.toInt()
-              val h = height.toInt()
+              val w = this.width.toInt()
+              val h = this.height.toInt()
               if (w <= 0 || h <= 0) return
               log.i { "Drawable size changed: ${w}x${h}" }
               prismSurface?.resize(w, h)

--- a/prism-compose/src/iosMain/kotlin/com/hyeonslab/prism/compose/PrismView.ios.kt
+++ b/prism-compose/src/iosMain/kotlin/com/hyeonslab/prism/compose/PrismView.ios.kt
@@ -1,0 +1,131 @@
+@file:OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+
+package com.hyeonslab.prism.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.interop.UIKitView
+import co.touchlab.kermit.Logger
+import com.hyeonslab.prism.widget.PrismSurface
+import com.hyeonslab.prism.widget.createPrismSurface
+import io.ygdrasil.webgpu.WGPUContext
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.CValue
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.useContents
+import platform.CoreGraphics.CGSize
+import platform.Foundation.NSOperationQueue
+import platform.MetalKit.MTKView
+import platform.MetalKit.MTKViewDelegateProtocol
+import platform.darwin.NSObject
+
+private val log = Logger.withTag("PrismView.iOS")
+
+// Default fallback dimensions when MTKView's drawableSize is not yet computed.
+private const val IOS_DEFAULT_WIDTH = 800
+private const val IOS_DEFAULT_HEIGHT = 600
+
+/**
+ * iOS implementation of [PrismView]. Embeds an [MTKView] inside the Compose layout via [UIKitView]
+ * and drives the engine render loop through [MTKViewDelegateProtocol].
+ *
+ * The MTKView display link fires at the target frame rate, calling
+ * [com.hyeonslab.prism.core.GameLoop.tick] each frame. FPS is smoothed and dispatched to [store] on
+ * the main queue. Surface resize notifications are forwarded as [EngineStateEvent.SurfaceResized]
+ * events.
+ *
+ * [onSurfaceReady] is invoked once after the wgpu surface is successfully created. Use it to
+ * initialize scene resources (e.g. upload meshes, configure a renderer) that require a live
+ * [WGPUContext].
+ */
+@Suppress("DEPRECATION") // UIKitView deprecated in CMP ≥ 1.7 in favour of newer interop APIs
+@Composable
+actual fun PrismView(
+  store: EngineStore,
+  modifier: Modifier,
+  onSurfaceReady: ((WGPUContext, Int, Int) -> Unit)?,
+) {
+  var mtkView by remember { mutableStateOf<MTKView?>(null) }
+  var prismSurface by remember { mutableStateOf<PrismSurface?>(null) }
+  // MTKView.delegate is a WEAK reference — store a strong ref here to prevent GC.
+  var renderDelegate by remember { mutableStateOf<MTKViewDelegateProtocol?>(null) }
+
+  UIKitView(factory = { MTKView().also { mtkView = it } }, modifier = modifier, interactive = false)
+
+  LaunchedEffect(mtkView) {
+    val view = mtkView ?: return@LaunchedEffect
+
+    var width = view.drawableSize.useContents { width.toInt() }
+    var height = view.drawableSize.useContents { height.toInt() }
+    if (width <= 0 || height <= 0) {
+      log.w { "drawableSize not ready (${width}x${height}), using defaults" }
+      width = IOS_DEFAULT_WIDTH
+      height = IOS_DEFAULT_HEIGHT
+    }
+
+    log.i { "Creating wgpu surface from MTKView: ${width}x${height}" }
+    try {
+      val s = createPrismSurface(view, width, height)
+      prismSurface = s
+      store.dispatch(EngineStateEvent.SurfaceResized(width, height))
+
+      val wgpuCtx = checkNotNull(s.wgpuContext) { "wgpu context not available after surface init" }
+      onSurfaceReady?.invoke(wgpuCtx, width, height)
+
+      val engine = store.engine
+      engine.gameLoop.startExternal()
+
+      val delegate =
+        object : NSObject(), MTKViewDelegateProtocol {
+          override fun drawInMTKView(view: MTKView) {
+            engine.gameLoop.tick()
+
+            val time = engine.time
+            val currentFps = store.state.value.fps
+            val smoothedFps =
+              if (time.deltaTime > 0f) currentFps * 0.9f + (1f / time.deltaTime) * 0.1f
+              else currentFps
+            NSOperationQueue.mainQueue.addOperationWithBlock {
+              store.dispatch(EngineStateEvent.FrameTick(time, smoothedFps))
+            }
+          }
+
+          override fun mtkView(view: MTKView, drawableSizeWillChange: CValue<CGSize>) {
+            drawableSizeWillChange.useContents {
+              val w = width.toInt()
+              val h = height.toInt()
+              if (w <= 0 || h <= 0) return
+              log.i { "Drawable size changed: ${w}x${h}" }
+              prismSurface?.resize(w, h)
+              NSOperationQueue.mainQueue.addOperationWithBlock {
+                store.dispatch(EngineStateEvent.SurfaceResized(w, h))
+              }
+            }
+          }
+        }
+
+      renderDelegate = delegate
+      view.delegate = delegate
+      log.i { "PrismView iOS render delegate installed (${width}x${height})" }
+    } catch (e: Exception) {
+      log.e(e) { "Failed to initialize wgpu surface: ${e.message}" }
+    }
+  }
+
+  DisposableEffect(store) {
+    onDispose {
+      log.i { "PrismView iOS disposing" }
+      mtkView?.delegate = null
+      renderDelegate = null
+      store.engine.gameLoop.stop()
+      prismSurface?.detach()
+      prismSurface = null
+    }
+  }
+}

--- a/prism-compose/src/jvmMain/kotlin/com/hyeonslab/prism/compose/PrismView.jvm.kt
+++ b/prism-compose/src/jvmMain/kotlin/com/hyeonslab/prism/compose/PrismView.jvm.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.SwingPanel
 import co.touchlab.kermit.Logger
 import com.hyeonslab.prism.widget.PrismPanel
+import io.ygdrasil.webgpu.WGPUContext
 
 private val log = Logger.withTag("PrismView.JVM")
 
@@ -25,7 +26,11 @@ private val log = Logger.withTag("PrismView.JVM")
  * All state changes are dispatched as [EngineStateEvent]s through [EngineStore.dispatch].
  */
 @Composable
-actual fun PrismView(store: EngineStore, modifier: Modifier) {
+actual fun PrismView(
+  store: EngineStore,
+  modifier: Modifier,
+  onSurfaceReady: ((WGPUContext, Int, Int) -> Unit)?,
+) {
   var panel by remember { mutableStateOf<PrismPanel?>(null) }
   var isReady by remember { mutableStateOf(false) }
 
@@ -50,13 +55,18 @@ actual fun PrismView(store: EngineStore, modifier: Modifier) {
       val p = panel ?: return@LaunchedEffect
       log.i { "Starting render loop" }
 
+      val ctx = p.wgpuContext
+      if (ctx != null) {
+        onSurfaceReady?.invoke(ctx, p.width, p.height)
+      }
+
       val engine = store.engine
       engine.gameLoop.startExternal()
 
       while (true) {
         withFrameNanos {
-          val ctx = p.wgpuContext
-          if (ctx == null || !p.isReady) return@withFrameNanos
+          val wgpuCtx = p.wgpuContext
+          if (wgpuCtx == null || !p.isReady) return@withFrameNanos
 
           engine.gameLoop.tick()
 

--- a/prism-compose/src/macosMain/kotlin/com/hyeonslab/prism/compose/PrismView.macos.kt
+++ b/prism-compose/src/macosMain/kotlin/com/hyeonslab/prism/compose/PrismView.macos.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.Modifier
 import co.touchlab.kermit.Logger
 import io.ygdrasil.webgpu.WGPUContext
 
-private val log = Logger.withTag("PrismView.WASM")
+private val log = Logger.withTag("PrismView.macOS")
 
 @Composable
 actual fun PrismView(
@@ -16,7 +16,7 @@ actual fun PrismView(
   onSurfaceReady: ((WGPUContext, Int, Int) -> Unit)?,
 ) {
   LaunchedEffect(Unit) {
-    log.w { "PrismView WASM stub \u2014 HTML Canvas/WebGPU integration not yet implemented" }
+    log.w { "PrismView macOS stub \u2014 Compose/Metal integration not yet implemented" }
   }
   DisposableEffect(store) { onDispose {} }
 }

--- a/prism-compose/src/nonNativeMain/kotlin/com/hyeonslab/prism/compose/PrismView.kt
+++ b/prism-compose/src/nonNativeMain/kotlin/com/hyeonslab/prism/compose/PrismView.kt
@@ -2,6 +2,7 @@ package com.hyeonslab.prism.compose
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import io.ygdrasil.webgpu.WGPUContext
 
 /**
  * Embeds a Prism 3D rendering surface inside a Compose layout.
@@ -17,5 +18,13 @@ import androidx.compose.ui.Modifier
  * @param store The MVI store managing engine state. Must be created via [rememberEngineStore] or
  *   [rememberExternalEngineStore].
  * @param modifier Compose modifier for layout and sizing.
+ * @param onSurfaceReady Optional callback invoked once when the GPU surface is ready. Receives the
+ *   [WGPUContext], surface width, and surface height. Use this to initialize scene resources that
+ *   require a live GPU context (e.g. uploading meshes, creating a renderer). Defaults to null.
  */
-@Composable expect fun PrismView(store: EngineStore, modifier: Modifier = Modifier)
+@Composable
+expect fun PrismView(
+  store: EngineStore,
+  modifier: Modifier = Modifier,
+  onSurfaceReady: ((WGPUContext, Int, Int) -> Unit)? = null,
+)

--- a/prism-core/src/commonMain/kotlin/com/hyeonslab/prism/core/GameLoop.kt
+++ b/prism-core/src/commonMain/kotlin/com/hyeonslab/prism/core/GameLoop.kt
@@ -10,6 +10,15 @@ class GameLoop {
   var onFixedUpdate: ((Time) -> Unit)? = null
   var onRender: ((Time) -> Unit)? = null
 
+  /**
+   * Optional single-fire callback invoked at the start of [stop], before the loop is marked as
+   * stopped. The callback is cleared immediately after it fires to prevent re-entrancy.
+   *
+   * Use this to release resources that must be freed while the render surface is still alive (e.g.
+   * scene GPU resource cleanup) before the platform closes the surface after [stop] returns.
+   */
+  var onStop: (() -> Unit)? = null
+
   private var accumulator: Float = 0f
   private var lastTimeMillis: Long = 0L
   private var totalTime: Float = 0f
@@ -26,6 +35,9 @@ class GameLoop {
   }
 
   fun stop() {
+    val cb = onStop
+    onStop = null // clear before invoking to prevent re-entrancy if stop() is called recursively
+    cb?.invoke()
     isRunning = false
   }
 

--- a/prism-core/src/commonMain/kotlin/com/hyeonslab/prism/core/GameLoop.kt
+++ b/prism-core/src/commonMain/kotlin/com/hyeonslab/prism/core/GameLoop.kt
@@ -35,6 +35,7 @@ class GameLoop {
   }
 
   fun stop() {
+    if (!isRunning) return
     val cb = onStop
     onStop = null // clear before invoking to prevent re-entrancy if stop() is called recursively
     cb?.invoke()

--- a/prism-demo-core/src/iosMain/kotlin/com/hyeonslab/prism/demo/ComposeIosEntry.kt
+++ b/prism-demo-core/src/iosMain/kotlin/com/hyeonslab/prism/demo/ComposeIosEntry.kt
@@ -12,11 +12,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,9 +31,7 @@ import com.hyeonslab.prism.compose.rememberEngineStore
 import com.hyeonslab.prism.core.EngineConfig
 import io.ygdrasil.webgpu.WGPUContext
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import platform.Foundation.NSOperationQueue
 import platform.UIKit.UIViewController
 
@@ -47,8 +45,13 @@ fun composeDemoViewController(): UIViewController = ComposeUIViewController {
 @Composable
 private fun IosComposeDemoContent() {
   val engineStore = rememberEngineStore(EngineConfig(appName = "Prism iOS Compose"))
+  // Scope for progressive glTF texture uploads. Tied to this composable's composition lifetime
+  // and automatically cancelled when it leaves; also explicitly cancelled in gameLoop.onStop
+  // (before scene.shutdown()) so uploads stop before the renderer frees GPU resources.
+  val backgroundScope = rememberCoroutineScope()
   val store = sharedDemoStore
   val uiState by store.state.collectAsStateWithLifecycle()
+  val engineState by engineStore.state.collectAsStateWithLifecycle()
 
   var scene by remember { mutableStateOf<DemoScene?>(null) }
   var surfaceCtx by remember { mutableStateOf<WGPUContext?>(null) }
@@ -56,15 +59,12 @@ private fun IosComposeDemoContent() {
   var surfaceHeight by remember { mutableStateOf(0) }
   var initError by remember { mutableStateOf<String?>(null) }
 
-  // Clean up scene resources when the composable leaves the composition. Null onRender first
-  // so no further callbacks fire into a shutting-down scene.
-  DisposableEffect(Unit) {
-    onDispose {
-      log.i { "Disposing Compose iOS demo" }
-      engineStore.engine.gameLoop.onRender = null
-      scene?.shutdown()
-      scene = null
-    }
+  // Update the scene's camera aspect ratio whenever the engine-reported surface dimensions change.
+  // This corrects the initial aspect ratio when PrismView fell back to the 800×600 default before
+  // the MTKView completed its first layout pass.
+  LaunchedEffect(engineState.surfaceWidth, engineState.surfaceHeight, scene) {
+    val sc = scene ?: return@LaunchedEffect
+    sc.updateAspectRatio(engineState.surfaceWidth, engineState.surfaceHeight)
   }
 
   // Once the surface is ready (surfaceCtx becomes non-null), create the glTF demo scene and
@@ -80,7 +80,9 @@ private fun IosComposeDemoContent() {
         checkNotNull(loadBundleAssetBytes("DamagedHelmet.glb")) {
           "DamagedHelmet.glb not found in app bundle"
         }
-      val backgroundScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+      // surfacePreConfigured defaults to false: WgpuRenderer will configure the wgpu surface on
+      // first use. createPrismSurface (called by PrismView) intentionally does not pre-configure
+      // the surface, so this is the correct default for the Compose path.
       val sc =
         createGltfDemoScene(
           ctx,
@@ -89,6 +91,16 @@ private fun IosComposeDemoContent() {
           glbData = glbBytes,
           progressiveScope = backgroundScope,
         )
+
+      // Register cleanup to run inside PrismView's gameLoop.stop(), which fires BEFORE the wgpu
+      // surface is detached. This ensures GPU resources are freed while the context is still
+      // valid, avoiding use-after-free if wgpu4k ever closes resources eagerly on context close.
+      engineStore.engine.gameLoop.onStop = {
+        engineStore.engine.gameLoop.onRender = null
+        backgroundScope.cancel() // stop progressive texture uploads before renderer is freed
+        sc.shutdown()
+      }
+
       scene = sc
       engineStore.dispatch(EngineStateEvent.SurfaceResized(w, h))
 

--- a/prism-demo-core/src/iosMain/kotlin/com/hyeonslab/prism/demo/ComposeIosEntry.kt
+++ b/prism-demo-core/src/iosMain/kotlin/com/hyeonslab/prism/demo/ComposeIosEntry.kt
@@ -21,23 +21,21 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color as ComposeColor
-import androidx.compose.ui.interop.UIKitView
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ComposeUIViewController
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.touchlab.kermit.Logger
-import com.hyeonslab.prism.widget.PrismSurface
-import com.hyeonslab.prism.widget.createPrismSurface
-import kotlinx.cinterop.BetaInteropApi
-import kotlinx.cinterop.CValue
+import com.hyeonslab.prism.compose.EngineStateEvent
+import com.hyeonslab.prism.compose.PrismView
+import com.hyeonslab.prism.compose.rememberEngineStore
+import com.hyeonslab.prism.core.EngineConfig
+import io.ygdrasil.webgpu.WGPUContext
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.useContents
-import platform.CoreGraphics.CGSize
-import platform.MetalKit.MTKView
-import platform.MetalKit.MTKViewDelegateProtocol
-import platform.QuartzCore.CACurrentMediaTime
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import platform.Foundation.NSOperationQueue
 import platform.UIKit.UIViewController
-import platform.darwin.NSObject
 
 private val log = Logger.withTag("ComposeIOS")
 
@@ -48,95 +46,92 @@ fun composeDemoViewController(): UIViewController = ComposeUIViewController {
 
 @Composable
 private fun IosComposeDemoContent() {
+  val engineStore = rememberEngineStore(EngineConfig(appName = "Prism iOS Compose"))
   val store = sharedDemoStore
   val uiState by store.state.collectAsStateWithLifecycle()
 
-  // Hold scene + surface + delegate so they survive recomposition but can be cleaned up.
-  // MTKView.delegate is a WEAK reference — without a strong ref here, the delegate gets GC'd.
   var scene by remember { mutableStateOf<DemoScene?>(null) }
-  var surface by remember { mutableStateOf<PrismSurface?>(null) }
-  var mtkView by remember { mutableStateOf<MTKView?>(null) }
-  var renderDelegate by remember { mutableStateOf<MTKViewDelegateProtocol?>(null) }
+  var surfaceCtx by remember { mutableStateOf<WGPUContext?>(null) }
+  var surfaceWidth by remember { mutableStateOf(0) }
+  var surfaceHeight by remember { mutableStateOf(0) }
   var initError by remember { mutableStateOf<String?>(null) }
 
-  // Clean up wgpu resources when the composable leaves the composition.
-  // Null the delegate first to stop render callbacks before shutting down.
+  // Clean up scene resources when the composable leaves the composition. Null onRender first
+  // so no further callbacks fire into a shutting-down scene.
   DisposableEffect(Unit) {
     onDispose {
       log.i { "Disposing Compose iOS demo" }
-      mtkView?.delegate = null
-      renderDelegate = null
+      engineStore.engine.gameLoop.onRender = null
       scene?.shutdown()
-      surface?.detach()
+      scene = null
+    }
+  }
+
+  // Once the surface is ready (surfaceCtx becomes non-null), create the glTF demo scene and
+  // wire per-frame logic (material overrides, scene tick, FPS dispatch) into the game loop.
+  LaunchedEffect(surfaceCtx) {
+    val ctx = surfaceCtx ?: return@LaunchedEffect
+    val w = surfaceWidth
+    val h = surfaceHeight
+
+    log.i { "Initializing glTF demo scene (${w}x${h})" }
+    try {
+      val glbBytes =
+        checkNotNull(loadBundleAssetBytes("DamagedHelmet.glb")) {
+          "DamagedHelmet.glb not found in app bundle"
+        }
+      val backgroundScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+      val sc =
+        createGltfDemoScene(
+          ctx,
+          width = w,
+          height = h,
+          glbData = glbBytes,
+          progressiveScope = backgroundScope,
+        )
+      scene = sc
+      engineStore.dispatch(EngineStateEvent.SurfaceResized(w, h))
+
+      // Wire per-frame logic into the game loop. This callback is invoked by
+      // PrismView.ios.kt's MTKViewDelegate on the display-link thread.
+      engineStore.engine.gameLoop.onRender = { time ->
+        val currentState = store.state.value
+        if (!currentState.isPaused) {
+          sc.setMaterialOverride(currentState.metallic, currentState.roughness)
+          sc.setEnvIntensity(currentState.envIntensity)
+        }
+        var elapsed = 0f
+        SharedDemoTime.tick(isPaused = currentState.isPaused) { e -> elapsed = e }
+        sc.tick(
+          deltaTime = if (currentState.isPaused) 0f else time.deltaTime,
+          elapsed = elapsed,
+          frameCount = time.frameCount,
+        )
+        if (time.deltaTime > 0f) {
+          val smoothedFps = currentState.fps * 0.9f + (1f / time.deltaTime) * 0.1f
+          NSOperationQueue.mainQueue.addOperationWithBlock {
+            store.dispatch(DemoIntent.UpdateFps(smoothedFps))
+          }
+        }
+      }
+      log.i { "Compose iOS demo initialized" }
+    } catch (e: Exception) {
+      log.e(e) { "Failed to initialize demo scene: ${e.message}" }
+      initError = e.message ?: "Failed to initialize GPU"
     }
   }
 
   MaterialTheme(colorScheme = darkColorScheme()) {
     Box(modifier = Modifier.fillMaxSize()) {
-      // MTKView embedded as a native UIKit view.
-      // interactive = false: this is a display-only Metal surface; all user interaction
-      // (sliders, buttons) is handled by the Compose overlay, not the MTKView.
-      @Suppress("DEPRECATION")
-      UIKitView(
-        factory = {
-          val device = platform.Metal.MTLCreateSystemDefaultDevice()
-          if (device == null) {
-            log.e { "Metal is not supported on this device" }
-            initError = "Metal is not supported on this device"
-          }
-          val view =
-            MTKView().apply {
-              this.device = device
-              this.colorPixelFormat = platform.Metal.MTLPixelFormatBGRA8Unorm
-              this.depthStencilPixelFormat = platform.Metal.MTLPixelFormatDepth32Float
-              this.preferredFramesPerSecond = 60
-            }
-          mtkView = view
-          view
-        },
+      PrismView(
+        store = engineStore,
         modifier = Modifier.fillMaxSize(),
-        interactive = false,
+        onSurfaceReady = { ctx, w, h ->
+          surfaceCtx = ctx
+          surfaceWidth = w
+          surfaceHeight = h
+        },
       )
-
-      // Initialize wgpu once the MTKView is available
-      LaunchedEffect(mtkView) {
-        val view = mtkView ?: return@LaunchedEffect
-        if (initError != null) return@LaunchedEffect
-
-        log.i { "Initializing wgpu for Compose iOS demo" }
-
-        var width = view.drawableSize.useContents { width.toInt() }
-        var height = view.drawableSize.useContents { height.toInt() }
-        if (width <= 0 || height <= 0) {
-          log.w { "drawableSize not ready (${width}x${height}), using defaults" }
-          width = IOS_DEFAULT_WIDTH
-          height = IOS_DEFAULT_HEIGHT
-        }
-
-        try {
-          val s = createPrismSurface(view, width, height)
-          surface = s
-          val wgpuCtx = checkNotNull(s.wgpuContext) { "wgpu context not available" }
-          val glbBytes =
-            checkNotNull(loadBundleAssetBytes("DamagedHelmet.glb")) {
-              "DamagedHelmet.glb not found in app bundle"
-            }
-          val sc = createGltfDemoScene(wgpuCtx, width = width, height = height, glbData = glbBytes)
-          scene = sc
-
-          val delegate =
-            ComposeRenderDelegate(sc, store) { w, h ->
-              sc.renderer.resize(w, h)
-              sc.updateAspectRatio(w, h)
-            }
-          renderDelegate = delegate
-          view.delegate = delegate
-          log.i { "Compose iOS demo initialized (${width}x${height})" }
-        } catch (e: Exception) {
-          log.e(e) { "Failed to initialize wgpu: ${e.message}" }
-          initError = e.message ?: "Failed to initialize GPU"
-        }
-      }
 
       // Show error overlay if initialization failed
       val error = initError
@@ -158,39 +153,6 @@ private fun IosComposeDemoContent() {
             .windowInsetsPadding(WindowInsets.safeDrawing)
             .padding(8.dp),
       )
-    }
-  }
-}
-
-/**
- * MTKView render delegate for the Compose iOS demo. Delegates per-frame update logic to
- * [tickDemoFrame] which is shared with the Native tab's [DemoRenderDelegate].
- */
-@OptIn(BetaInteropApi::class)
-private class ComposeRenderDelegate(
-  private val scene: DemoScene,
-  private val store: DemoStore,
-  private val onResize: (Int, Int) -> Unit,
-) : NSObject(), MTKViewDelegateProtocol {
-
-  private var lastFrameTime = CACurrentMediaTime()
-  private var frameCount = 0L
-
-  override fun drawInMTKView(view: MTKView) {
-    val now = CACurrentMediaTime()
-    val deltaTime = (now - lastFrameTime).toFloat()
-    lastFrameTime = now
-    frameCount++
-    tickDemoFrame(scene, store, deltaTime, frameCount)
-  }
-
-  override fun mtkView(view: MTKView, drawableSizeWillChange: CValue<CGSize>) {
-    drawableSizeWillChange.useContents {
-      val w = width.toInt()
-      val h = height.toInt()
-      if (w <= 0 || h <= 0) return
-      log.i { "Compose drawable size changed: ${w}x${h}" }
-      onResize(w, h)
     }
   }
 }

--- a/prism-flutter/flutter_plugin/ios/prism_flutter/Sources/prism_flutter/PrismFlutterPlugin.swift
+++ b/prism-flutter/flutter_plugin/ios/prism_flutter/Sources/prism_flutter/PrismFlutterPlugin.swift
@@ -62,7 +62,7 @@ private class PrismMetalView: UIView {
         super.layoutSubviews()
         guard let mtkView = mtkView, engineHandle != 0 else { return }
         mtkView.frame = bounds
-        let scale = UIScreen.main.scale
+        let scale = (window?.screen ?? UIScreen.main).scale
         let width = Int32(bounds.width * scale)
         let height = Int32(bounds.height * scale)
         prism_resize(engineHandle, width, height)
@@ -101,7 +101,7 @@ class PrismIOSPlatformView: NSObject, FlutterPlatformView {
         _view.mtkView = mtkView
 
         let rawPtr = Unmanaged.passUnretained(mtkView).toOpaque()
-        let scale = UIScreen.main.scale
+        let scale = (window?.screen ?? UIScreen.main).scale
         let width = Int32(_view.bounds.width * scale)
         let height = Int32(_view.bounds.height * scale)
 

--- a/prism-flutter/flutter_plugin/ios/prism_flutter/Sources/prism_flutter/PrismFlutterPlugin.swift
+++ b/prism-flutter/flutter_plugin/ios/prism_flutter/Sources/prism_flutter/PrismFlutterPlugin.swift
@@ -1,6 +1,6 @@
 import Flutter
+import MetalKit
 import UIKit
-import QuartzCore
 
 public class PrismFlutterPlugin: NSObject, FlutterPlugin {
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -50,17 +50,21 @@ class PrismIOSPlatformViewFactory: NSObject, FlutterPlatformViewFactory {
     }
 }
 
-/// A UIView subclass that forwards layout changes to the Kotlin/Native prism_resize C API.
+/// A UIView subclass that holds the embedded MTKView and forwards layout changes to
+/// the Kotlin/Native prism_resize C API.
 private class PrismMetalView: UIView {
     var engineHandle: Int64 = 0
-    var metalLayer: CAMetalLayer?
+    /// Strong reference to the embedded MTKView. MTKView is a subview of this container so ARC
+    /// keeps it alive while the Kotlin/Native side holds a raw pointer to it.
+    var mtkView: MTKView?
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        guard let layer = metalLayer, engineHandle != 0 else { return }
-        layer.frame = bounds
-        let width = Int32(bounds.width * layer.contentsScale)
-        let height = Int32(bounds.height * layer.contentsScale)
+        guard let mtkView = mtkView, engineHandle != 0 else { return }
+        mtkView.frame = bounds
+        let scale = UIScreen.main.scale
+        let width = Int32(bounds.width * scale)
+        let height = Int32(bounds.height * scale)
         prism_resize(engineHandle, width, height)
     }
 }
@@ -80,7 +84,7 @@ class PrismIOSPlatformView: NSObject, FlutterPlatformView {
         super.init()
 
         if engineHandle != 0 {
-            setupMetalLayer()
+            setupMtkView()
         }
     }
 
@@ -88,18 +92,18 @@ class PrismIOSPlatformView: NSObject, FlutterPlatformView {
         return _view
     }
 
-    private func setupMetalLayer() {
-        let layer = CAMetalLayer()
-        layer.frame = _view.bounds
-        layer.contentsScale = UIScreen.main.scale
-        _view.layer.addSublayer(layer)
-        // Retain the layer via the strong property on the view so ARC keeps it alive while the
-        // Kotlin/Native side holds a raw pointer to it.
-        _view.metalLayer = layer
+    private func setupMtkView() {
+        let mtkView = MTKView(frame: _view.bounds)
+        mtkView.device = MTLCreateSystemDefaultDevice()
+        _view.addSubview(mtkView)
+        // Retain via the strong property on the container view so ARC keeps the MTKView alive
+        // while the Kotlin/Native side holds a raw pointer to it.
+        _view.mtkView = mtkView
 
-        let rawPtr = Unmanaged.passUnretained(layer).toOpaque()
-        let width = Int32(layer.bounds.width * layer.contentsScale)
-        let height = Int32(layer.bounds.height * layer.contentsScale)
+        let rawPtr = Unmanaged.passUnretained(mtkView).toOpaque()
+        let scale = UIScreen.main.scale
+        let width = Int32(_view.bounds.width * scale)
+        let height = Int32(_view.bounds.height * scale)
 
         prism_attach_metal_layer(engineHandle, rawPtr, width, height)
 
@@ -114,13 +118,13 @@ class PrismIOSPlatformView: NSObject, FlutterPlatformView {
     deinit {
         displayLink?.invalidate()
         prism_detach_surface(engineHandle)
-        _view.metalLayer = nil
+        _view.mtkView = nil
     }
 }
 
 // C API bindings (provided by PrismNative.xcframework)
 @_silgen_name("prism_attach_metal_layer")
-func prism_attach_metal_layer(_ handle: Int64, _ layer: UnsafeMutableRawPointer, _ width: Int32, _ height: Int32)
+func prism_attach_metal_layer(_ handle: Int64, _ ptr: UnsafeMutableRawPointer, _ width: Int32, _ height: Int32)
 
 @_silgen_name("prism_render_frame")
 func prism_render_frame(_ handle: Int64)

--- a/prism-flutter/flutter_plugin/ios/prism_flutter/Sources/prism_flutter/PrismFlutterPlugin.swift
+++ b/prism-flutter/flutter_plugin/ios/prism_flutter/Sources/prism_flutter/PrismFlutterPlugin.swift
@@ -101,7 +101,7 @@ class PrismIOSPlatformView: NSObject, FlutterPlatformView {
         _view.mtkView = mtkView
 
         let rawPtr = Unmanaged.passUnretained(mtkView).toOpaque()
-        let scale = (window?.screen ?? UIScreen.main).scale
+        let scale = _view.window?.screen?.scale ?? UIScreen.main.scale
         let width = Int32(_view.bounds.width * scale)
         let height = Int32(_view.bounds.height * scale)
 

--- a/prism-native/build.gradle.kts
+++ b/prism-native/build.gradle.kts
@@ -28,6 +28,10 @@ kotlin {
         implementation(libs.wgpu4k.toolkit)
         implementation(libs.kotlinx.coroutines.core)
       }
+      iosMain.dependencies {
+        implementation(libs.wgpu4k.toolkit)
+        implementation(libs.kotlinx.coroutines.core)
+      }
     }
   }
 

--- a/prism-native/src/iosMain/kotlin/engine/prism/native/IosBridge.kt
+++ b/prism-native/src/iosMain/kotlin/engine/prism/native/IosBridge.kt
@@ -18,6 +18,7 @@ import kotlin.experimental.ExperimentalNativeApi
 import kotlin.native.CName
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.getAndUpdate
 import kotlinx.atomicfu.update
 import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -67,10 +68,13 @@ fun prismAttachMetalLayer(engineHandle: Long, layerPtr: COpaquePointer?, width: 
     )
   )
 
+  // Insert into the map BEFORE starting the game loop. The CADisplayLink fires immediately
+  // after startExternal() and prismRenderFrame checks iosSurfaces — inserting first prevents
+  // a dropped first frame.
+  iosSurfaces.update { it + (engineHandle to ctx) }
   // Guard against calling startExternal() a second time if the caller re-attaches to the same
   // engine handle (e.g. view recreated after returning to the screen).
   if (!engine.gameLoop.isRunning) engine.gameLoop.startExternal()
-  iosSurfaces.update { it + (engineHandle to ctx) }
 }
 
 /**
@@ -131,6 +135,9 @@ fun prismRenderFrame(engineHandle: Long) {
  * call.
  */
 @CName("prism_resize")
+// width and height are intentionally unused: the MTKView tracks its own drawable dimensions and
+// surface.configure() reads them directly from the underlying Metal layer. The parameters are kept
+// in the signature for ABI compatibility with the Swift caller.
 @Suppress("UNUSED_PARAMETER")
 fun prismResize(engineHandle: Long, width: Int, height: Int) {
   val ctx = iosSurfaces.value[engineHandle] ?: return
@@ -156,11 +163,8 @@ fun prismDetachSurface(engineHandle: Long) {
   val engine = Registry.get<Engine>(engineHandle)
   engine?.gameLoop?.stop()
 
-  var closedCtx: IosContext? = null
-  iosSurfaces.update {
-    val ctx = it[engineHandle]
-    closedCtx = ctx
-    it - engineHandle
-  }
-  closedCtx?.close()
+  // getAndUpdate returns the old map; look up the removed context and close it outside the
+  // lambda, which must be a pure transform with no side effects.
+  val oldMap = iosSurfaces.getAndUpdate { it - engineHandle }
+  oldMap[engineHandle]?.close()
 }

--- a/prism-native/src/iosMain/kotlin/engine/prism/native/IosBridge.kt
+++ b/prism-native/src/iosMain/kotlin/engine/prism/native/IosBridge.kt
@@ -1,0 +1,166 @@
+@file:OptIn(ExperimentalNativeApi::class, ExperimentalForeignApi::class)
+
+package engine.prism.native
+
+import com.hyeonslab.prism.core.Engine
+import io.ygdrasil.webgpu.Color
+import io.ygdrasil.webgpu.CompositeAlphaMode
+import io.ygdrasil.webgpu.GPULoadOp
+import io.ygdrasil.webgpu.GPUStoreOp
+import io.ygdrasil.webgpu.IosContext
+import io.ygdrasil.webgpu.RenderPassColorAttachment
+import io.ygdrasil.webgpu.RenderPassDescriptor
+import io.ygdrasil.webgpu.SurfaceConfiguration
+import io.ygdrasil.webgpu.SurfaceRenderingContext
+import io.ygdrasil.webgpu.beginRenderPass
+import io.ygdrasil.webgpu.iosContextRenderer
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.CName
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
+import kotlinx.cinterop.COpaquePointer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.interpretObjCPointerOrNull
+import kotlinx.cinterop.rawValue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import platform.MetalKit.MTKView
+
+// ---------------------------------------------------------------------------
+// Per-engine Metal surface storage
+// ---------------------------------------------------------------------------
+
+private val iosSurfaces: AtomicRef<Map<Long, IosContext>> = atomic(mapOf())
+
+// ---------------------------------------------------------------------------
+// iOS Metal surface API
+// ---------------------------------------------------------------------------
+
+/**
+ * Attaches a wgpu Metal surface to the engine identified by [engineHandle].
+ *
+ * [layerPtr] is the raw `MTKView *` pointer obtained via
+ * `Unmanaged.passUnretained(mtkView).toOpaque()` in Swift. [width] and [height] are the initial
+ * drawable dimensions in pixels.
+ *
+ * The engine game-loop is started in external-tick mode; call [prismRenderFrame] each frame to
+ * advance time and submit a render pass.
+ */
+@CName("prism_attach_metal_layer")
+fun prismAttachMetalLayer(engineHandle: Long, layerPtr: COpaquePointer?, width: Int, height: Int) {
+  val engine = Registry.get<Engine>(engineHandle) ?: return
+  val ptr = layerPtr ?: return
+  val mtkView = interpretObjCPointerOrNull<MTKView>(ptr.rawValue) ?: return
+
+  val ctx = runBlocking(Dispatchers.Default) { iosContextRenderer(mtkView, width, height) }
+
+  val surface = ctx.wgpuContext.surface
+  val alphaMode =
+    CompositeAlphaMode.Inherit.takeIf { surface.supportedAlphaMode.contains(it) }
+      ?: CompositeAlphaMode.Opaque
+  surface.configure(
+    SurfaceConfiguration(
+      device = ctx.wgpuContext.device,
+      format = ctx.wgpuContext.renderingContext.textureFormat,
+      alphaMode = alphaMode,
+    )
+  )
+
+  // Guard against calling startExternal() a second time if the caller re-attaches to the same
+  // engine handle (e.g. view recreated after returning to the screen).
+  if (!engine.gameLoop.isRunning) engine.gameLoop.startExternal()
+  iosSurfaces.update { it + (engineHandle to ctx) }
+}
+
+/**
+ * Advances the engine by one frame and submits a wgpu render pass.
+ *
+ * Ticks the game-loop (updates time / fixed-update callbacks), then executes a clear-color render
+ * pass via wgpu and presents the frame. Must be called from the CADisplayLink or MTKViewDelegate
+ * callback each frame.
+ */
+@CName("prism_render_frame")
+fun prismRenderFrame(engineHandle: Long) {
+  val engine = Registry.get<Engine>(engineHandle) ?: return
+  val ctx = iosSurfaces.value[engineHandle] ?: return
+
+  engine.gameLoop.tick()
+
+  val device = ctx.wgpuContext.device
+  val renderingContext = ctx.wgpuContext.renderingContext
+  val surface = ctx.wgpuContext.surface
+
+  val encoder = device.createCommandEncoder()
+  val texture = renderingContext.getCurrentTexture()
+  val view = texture.createView()
+
+  encoder.beginRenderPass(
+    RenderPassDescriptor(
+      colorAttachments =
+        listOf(
+          RenderPassColorAttachment(
+            view = view,
+            loadOp = GPULoadOp.Clear,
+            clearValue = Color(0.05, 0.05, 0.1, 1.0),
+            storeOp = GPUStoreOp.Store,
+          )
+        )
+    )
+  ) {
+    end()
+  }
+
+  val commandBuffer = encoder.finish()
+  device.queue.submit(listOf(commandBuffer))
+  view.close()
+  commandBuffer.close()
+  encoder.close()
+
+  if (renderingContext is SurfaceRenderingContext) {
+    surface.present()
+  }
+  texture.close()
+}
+
+/**
+ * Reconfigures the wgpu Metal surface for the new [width]/[height].
+ *
+ * Call this from `layoutSubviews` or `mtkView(_:drawableSizeWillChange:)` whenever the drawable
+ * dimensions change. This clears the `Outdated` surface status before the next [prismRenderFrame]
+ * call.
+ */
+@CName("prism_resize")
+@Suppress("UNUSED_PARAMETER")
+fun prismResize(engineHandle: Long, width: Int, height: Int) {
+  val ctx = iosSurfaces.value[engineHandle] ?: return
+  val surface = ctx.wgpuContext.surface
+  val alphaMode =
+    CompositeAlphaMode.Inherit.takeIf { surface.supportedAlphaMode.contains(it) }
+      ?: CompositeAlphaMode.Opaque
+  surface.configure(
+    SurfaceConfiguration(
+      device = ctx.wgpuContext.device,
+      format = ctx.wgpuContext.renderingContext.textureFormat,
+      alphaMode = alphaMode,
+    )
+  )
+}
+
+/**
+ * Detaches the wgpu Metal surface from the engine and releases GPU resources. After this call,
+ * [prismRenderFrame] is a no-op for this engine handle.
+ */
+@CName("prism_detach_surface")
+fun prismDetachSurface(engineHandle: Long) {
+  val engine = Registry.get<Engine>(engineHandle)
+  engine?.gameLoop?.stop()
+
+  var closedCtx: IosContext? = null
+  iosSurfaces.update {
+    val ctx = it[engineHandle]
+    closedCtx = ctx
+    it - engineHandle
+  }
+  closedCtx?.close()
+}

--- a/prism-native/src/macosMain/kotlin/engine/prism/native/MacosBridge.kt
+++ b/prism-native/src/macosMain/kotlin/engine/prism/native/MacosBridge.kt
@@ -19,6 +19,7 @@ import kotlin.experimental.ExperimentalNativeApi
 import kotlin.native.CName
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.getAndUpdate
 import kotlinx.atomicfu.update
 import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -67,11 +68,14 @@ fun prismAttachMetalLayer(engineHandle: Long, layerPtr: COpaquePointer?, width: 
     )
   )
 
+  // Insert into the map BEFORE starting the game loop. The MTKViewDelegate fires immediately
+  // after startExternal() and prismRenderFrame checks macosSurfaces — inserting first prevents
+  // a dropped first frame.
+  macosSurfaces.update { it + (engineHandle to ctx) }
   // Guard against calling startExternal() a second time if the caller re-attaches to the same
   // engine handle (e.g. window moved to a different display). The game loop must not be started
   // twice — doing so would cause duplicate tick callbacks.
   if (!engine.gameLoop.isRunning) engine.gameLoop.startExternal()
-  macosSurfaces.update { it + (engineHandle to ctx) }
 }
 
 /**
@@ -159,11 +163,8 @@ fun prismDetachSurface(engineHandle: Long) {
   val engine = Registry.get<Engine>(engineHandle)
   engine?.gameLoop?.stop()
 
-  var closedCtx: MacosContext? = null
-  macosSurfaces.update {
-    val ctx = it[engineHandle]
-    closedCtx = ctx
-    it - engineHandle
-  }
-  closedCtx?.close()
+  // getAndUpdate returns the old map; look up the removed context and close it outside the
+  // lambda, which must be a pure transform with no side effects.
+  val oldMap = macosSurfaces.getAndUpdate { it - engineHandle }
+  oldMap[engineHandle]?.close()
 }


### PR DESCRIPTION
- Add `prism-native/src/iosMain/IosBridge.kt` exporting the four C symbols
  (`prism_attach_metal_layer`, `prism_render_frame`, `prism_resize`,
  `prism_detach_surface`) via `@CName`. Reconstructs `MTKView` from opaque
  pointer with `interpretObjCPointerOrNull`, creates wgpu `IosContext` via
  `iosContextRenderer`, and drives a clear-colour render pass per frame.
- Wire `prism-native/build.gradle.kts` `iosMain` source set with
  `wgpu4k.toolkit` + `kotlinx.coroutines.core` dependencies.
- Add `onSurfaceReady: ((WGPUContext, Int, Int) -> Unit)? = null` to the
  `PrismView` expect/actual across all platforms (JVM, Android, WASM, iOS,
  macOS). Callback fires once after the GPU surface is ready.
- Split `appleMain/PrismView.apple.kt` stub into:
  - `iosMain/PrismView.ios.kt` — full `UIKitView(MTKView)` +
    `MTKViewDelegateProtocol` implementation (display-link driven render loop)
  - `macosMain/PrismView.macos.kt` — stub (macOS Compose/Metal not yet
    implemented)
- Refactor `ComposeIosEntry.kt` to use `PrismView(onSurfaceReady = { ... })`
  instead of manual `UIKitView + ComposeRenderDelegate`; scene init happens in
  `LaunchedEffect(surfaceCtx)`, per-frame logic via `gameLoop.onRender`.
- Update `PrismFlutterPlugin.swift` to embed an `MTKView` subview instead of a
  `CAMetalLayer` sublayer, passing the `MTKView *` opaque pointer to
  `prism_attach_metal_layer` so `IosBridge` can reconstruct it.
- Add `GameLoop.onStop` single-fire callback invoked at the start of `stop()`;
  used by `ComposeIosEntry` to run scene GPU cleanup before `PrismView` detaches
  the wgpu surface (fixes disposal-ordering bug).
- Fix `IosBridge` / `MacosBridge`: insert surface into map before calling
  `startExternal()` (was dropping the first render frame); use `getAndUpdate`
  instead of side-effectful `update` lambda in `prismDetachSurface`.
- `ComposeIosEntry`: use `rememberCoroutineScope()` for progressive texture
  scope (was leaking a manually-created scope); add `LaunchedEffect` to update
  camera aspect ratio on surface resize.
- `PrismFlutterPlugin.swift`: replace deprecated `UIScreen.main.scale` with
  `(window?.screen ?? UIScreen.main).scale`.