### PR TITLE
fix: copy WASM artifacts recursively in deploy-docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -60,7 +60,7 @@ jobs:
           cp -r docs/ _site/
           # Overlay freshly built WASM artifacts; hand-written files in docs/wasm/
           # (DamagedHelmet.glb, index.html, pbr.html) are preserved from the cp above.
-          cp prism-demo-core/build/dist/wasmJs/productionExecutable/* _site/wasm/
+          cp -R prism-demo-core/build/dist/wasmJs/productionExecutable/. _site/wasm/
           touch _site/.nojekyll
 
       - name: Configure Pages

--- a/devlog/000023-fix-deploy-docs-cp.md
+++ b/devlog/000023-fix-deploy-docs-cp.md
@@ -1,0 +1,39 @@
+# 000023 — fix/deploy-docs-cp
+
+**Agent:** Claude (claude-opus-4-7) @ prism branch fix/deploy-docs-cp
+
+## Intent
+
+Fix the `Deploy Docs` workflow that has been failing on every push to `main`
+since `composeResources/` started appearing in the WASM distribution. Run
+`24959988342` (sha `ccda5e8`) is the most recent failure.
+
+## What Changed
+
+- 2026-05-08T19:18-0700 `.github/workflows/deploy-docs.yml` — change
+  `Stage docs site` to use `cp -R productionExecutable/. _site/wasm/` so the
+  new `composeResources/` subdirectory copies recursively instead of being
+  skipped with a non-zero exit.
+- 2026-05-08T19:18-0700 `devlog/plans/000023-01-deploy-docs-cp-fix.md` —
+  plan documenting the failure and the chosen fix.
+
+## Decisions
+
+- 2026-05-08T19:18-0700 Recursive copy of the entire `productionExecutable/`
+  tree (option 1 in the plan) over filtering out `composeResources/` (option 2).
+  Reasoning: the step's intent is "overlay freshly built WASM artifacts",
+  and the docs HTML may eventually depend on Compose resources. Filtering
+  risks silently dropping a needed file with no real benefit; recursion is
+  the conservative match for the original intent.
+- 2026-05-08T19:18-0700 Use `cp -R src/.` rather than `cp -r src/*`. The
+  trailing `/.` form includes hidden entries and avoids glob expansion
+  edge cases on otherwise-empty directories.
+
+## Issues
+
+None encountered. Cannot trigger the workflow from a PR (it's `push: main`-only),
+so verification has to happen on the post-merge run.
+
+## Commits
+
+- HEAD — fix: copy WASM artifacts recursively in deploy-docs

--- a/devlog/plans/000023-01-deploy-docs-cp-fix.md
+++ b/devlog/plans/000023-01-deploy-docs-cp-fix.md
@@ -1,0 +1,45 @@
+# Plan: fix Deploy Docs `cp` failure on `composeResources/`
+
+## Thinking
+
+The `Deploy Docs` workflow on `main` failed at the `Stage docs site` step
+(run `24959988342`):
+
+```
+cp: -r not specified; omitting directory 'prism-demo-core/build/dist/wasmJs/productionExecutable/composeResources'
+##[error]Process completed with exit code 1.
+```
+
+The current step uses a non-recursive copy:
+
+```bash
+cp prism-demo-core/build/dist/wasmJs/productionExecutable/* _site/wasm/
+```
+
+This worked when the WASM distribution was a flat set of files. The recent
+WASM build now emits a `composeResources/` subdirectory inside
+`productionExecutable/`, so plain `cp` skips it and exits non-zero.
+
+Two reasonable options:
+
+1. Add `-R` and use the `src/.` form to copy everything including any
+   hidden files/subdirs into `_site/wasm/`:
+   `cp -R prism-demo-core/build/dist/wasmJs/productionExecutable/. _site/wasm/`
+2. Filter out `composeResources/` if the docs site doesn't need it.
+
+Option 1 is the safest and matches the step's intent ("overlay freshly
+built WASM artifacts"). The static demo HTML pages may eventually rely on
+resources from that subdir; even if not, copying it is harmless and a few
+KB. Option 2 risks dropping a file the demo needs without a clear payoff.
+
+Going with option 1.
+
+## Plan
+
+1. Edit `.github/workflows/deploy-docs.yml`: change the bare `cp` to
+   `cp -R …/productionExecutable/. _site/wasm/`.
+2. Create devlog `devlog/000023-fix-deploy-docs-cp.md`.
+3. Commit (`fix: copy WASM artifacts recursively in deploy-docs`).
+4. Push and open a PR. Verify the next `Deploy Docs` run on `main` after
+   merge succeeds (the workflow only triggers on `push` to `main`, not on
+   PR branches).


### PR DESCRIPTION
The Deploy Docs workflow's "Stage docs site" step used a bare `cp` that silently fails on directories. Recent WASM builds emit a `composeResources/` subdirectory inside `productionExecutable/`, which caused `cp` to skip it and exit non-zero, failing every push-to-main run since (most recently [run 24959988342](https://github.com/hyeons-lab/prism/actions/runs/24959988342)).

Switch to `cp -R productionExecutable/. _site/wasm/` so the entire distribution tree, including any new subdirectories, copies into the docs site.

## Test plan
- [ ] Cannot trigger `Deploy Docs` from a PR — it's `push: main`-only. Verify via the post-merge run, which should reach `Configure Pages` / `Upload pages artifact` / `Deploy to GitHub Pages` instead of failing in `Stage docs site`.