### PR TITLE
ci: parallelize Apple XCFramework slices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,18 @@ jobs:
           done
           echo "| **Total ~/.gradle** | $(du -sh ~/.gradle | cut -f1) |" >> "$GITHUB_STEP_SUMMARY"
 
-  apple:
-    name: Apple Targets
+  # The Apple build is split into per-slice matrix jobs that compile each
+  # Kotlin/Native target in parallel, then a finalize job that merges the
+  # per-slice .framework directories into XCFrameworks via
+  # `xcodebuild -create-xcframework` and runs the iOS demo build.
+  apple-slice:
+    name: Apple Slice (${{ matrix.target }})
     runs-on: macos-26
-    timeout-minutes: 70
+    timeout-minutes: 50
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [iosArm64, iosSimulatorArm64, macosArm64]
 
     steps:
       - name: Checkout
@@ -127,24 +135,41 @@ jobs:
         with:
           rust-targets: aarch64-apple-ios,aarch64-apple-ios-sim
 
-      - name: Apple native tests + XCFrameworks
+      - name: Build slice
         run: |
           START=$SECONDS
-          ./gradlew iosSimulatorArm64Test \
-            macosArm64Test \
-            :prism-demo-core:assemblePrismDemoDebugXCFramework \
-            :prism-ios:assemblePrismDebugXCFramework \
-            :prism-native:linkDebugSharedIosSimulatorArm64 \
-            :prism-native:linkDebugSharedMacosArm64 \
-            --configuration-cache \
-            -Pkotlin.native.parallelThreads=3 || EXIT=$?
-          echo "### Apple Tests + XCFrameworks: $((SECONDS - START))s" >> "$GITHUB_STEP_SUMMARY"
+          case "${{ matrix.target }}" in
+            iosArm64)
+              ./gradlew \
+                :prism-ios:linkDebugFrameworkIosArm64 \
+                :prism-demo-core:linkDebugFrameworkIosArm64 \
+                --configuration-cache \
+                -Pkotlin.native.parallelThreads=3 || EXIT=$?
+              ;;
+            iosSimulatorArm64)
+              ./gradlew \
+                :prism-ios:linkDebugFrameworkIosSimulatorArm64 \
+                :prism-demo-core:linkDebugFrameworkIosSimulatorArm64 \
+                :prism-native:linkDebugSharedIosSimulatorArm64 \
+                iosSimulatorArm64Test \
+                --configuration-cache \
+                -Pkotlin.native.parallelThreads=3 || EXIT=$?
+              ;;
+            macosArm64)
+              ./gradlew \
+                :prism-native:linkDebugSharedMacosArm64 \
+                macosArm64Test \
+                --configuration-cache \
+                -Pkotlin.native.parallelThreads=3 || EXIT=$?
+              ;;
+          esac
+          echo "### ${{ matrix.target }} slice: $((SECONDS - START))s" >> "$GITHUB_STEP_SUMMARY"
           exit ${EXIT:-0}
 
       - name: Gradle home cache size breakdown
         if: always()
         run: |
-          echo "### Gradle Home Cache Size" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Gradle Home Cache Size — ${{ matrix.target }}" >> "$GITHUB_STEP_SUMMARY"
           echo "| Directory | Size |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-----------|------|" >> "$GITHUB_STEP_SUMMARY"
           for D in modules-2 transforms-3 transforms-4 build-cache-1 kotlin-dce; do
@@ -155,6 +180,74 @@ jobs:
             fi
           done
           echo "| **Total ~/.gradle** | $(du -sh ~/.gradle | cut -f1) |" >> "$GITHUB_STEP_SUMMARY"
+
+      # Only the iOS slices contribute frameworks to the XCFramework merge.
+      # macosArm64 runs tests + the prism-native dylib for verification only;
+      # nothing from it is consumed downstream, so no upload is needed.
+      - name: Upload slice frameworks
+        if: matrix.target == 'iosArm64' || matrix.target == 'iosSimulatorArm64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: apple-slice-${{ matrix.target }}
+          path: |
+            prism-ios/build/bin/${{ matrix.target }}/debugFramework/
+            prism-demo-core/build/bin/${{ matrix.target }}/debugFramework/
+          if-no-files-found: error
+          retention-days: 1
+          include-hidden-files: true
+
+  apple-finalize:
+    name: Apple Finalize
+    needs: apple-slice
+    runs-on: macos-26
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download iOS slice frameworks
+        uses: actions/download-artifact@v4
+        with:
+          pattern: apple-slice-*
+          merge-multiple: true
+
+      - name: Inspect downloaded slice tree
+        run: |
+          echo "### Downloaded slice tree" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          find prism-ios/build/bin prism-demo-core/build/bin -maxdepth 5 -type d 2>/dev/null \
+            | sort >> "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Assemble XCFrameworks
+        run: |
+          set -euo pipefail
+          START=$SECONDS
+
+          create_xcf() {
+            local module="$1" name="$2"
+            local out="${module}/build/XCFrameworks/debug/${name}.xcframework"
+            local arm64="${module}/build/bin/iosArm64/debugFramework/${name}.framework"
+            local sim="${module}/build/bin/iosSimulatorArm64/debugFramework/${name}.framework"
+
+            if [ ! -d "$arm64" ] || [ ! -d "$sim" ]; then
+              echo "::error::Missing input slice framework for ${name}: arm64=${arm64} sim=${sim}"
+              exit 1
+            fi
+
+            rm -rf "$out"
+            mkdir -p "$(dirname "$out")"
+            xcodebuild -create-xcframework \
+              -framework "$arm64" \
+              -framework "$sim" \
+              -output "$out"
+          }
+
+          create_xcf prism-ios       Prism
+          create_xcf prism-demo-core PrismDemo
+
+          echo "### XCFramework merge: $((SECONDS - START))s" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Verify XCFramework headers
         run: |
@@ -207,8 +300,22 @@ jobs:
         if: steps.cache-xcodegen.outputs.cache-hit == 'true'
         run: brew link --overwrite xcodegen 2>/dev/null || true
 
+      # Replicates `:downloadDemoAssets` (see root build.gradle.kts) without
+      # paying for a Gradle/JDK setup just to fetch a single 3.7 MB file.
+      # The SHA-256 must stay in sync with build.gradle.kts.
       - name: Download demo assets
-        run: ./gradlew downloadDemoAssets
+        run: |
+          set -euo pipefail
+          DEST=prism-demo-core/assets/DamagedHelmet.glb
+          URL=https://github.com/KhronosGroup/glTF-Sample-Assets/raw/main/Models/DamagedHelmet/glTF-Binary/DamagedHelmet.glb
+          EXPECTED=a1e3b04de97b11de564ce6e53b95f02954a297f0008183ac63a4f5974f6b32d8
+          mkdir -p "$(dirname "$DEST")"
+          curl -fsSL "$URL" -o "$DEST"
+          ACTUAL=$(shasum -a 256 "$DEST" | cut -d' ' -f1)
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::DamagedHelmet.glb checksum mismatch: expected $EXPECTED, got $ACTUAL"
+            exit 1
+          fi
 
       - name: Generate Xcode project
         run: cd prism-ios-demo && xcodegen generate
@@ -241,7 +348,7 @@ jobs:
           fi
           echo "### xcodebuild: $((SECONDS - START))s" >> "$GITHUB_STEP_SUMMARY"
           exit ${EXIT:-0}
-          
+
   flutter:
     name: Flutter Dart Analysis
     runs-on: ubuntu-latest

--- a/devlog/000024-ci-parallel-apple-slices.md
+++ b/devlog/000024-ci-parallel-apple-slices.md
@@ -1,0 +1,66 @@
+# 000024 — ci/parallel-apple-slices
+
+**Agent:** Claude (claude-opus-4-7) @ prism branch ci/parallel-apple-slices
+
+## Intent
+
+Cut wall-clock time of the `Apple Targets` CI job by compiling per-slice
+Kotlin/Native frameworks (iosArm64, iosSimulatorArm64, macosArm64) on
+parallel macOS runners and merging them into XCFrameworks via
+`xcodebuild -create-xcframework` in a finalize job.
+
+User explicitly framed the design: "compile them in parallel, and then
+merge them — that would be faster".
+
+Baseline (run 24959988333): "Apple native tests + XCFrameworks" step =
+14m 12s out of a 17m total job.
+
+## What Changed
+
+- 2026-05-08T19:38-0700 `.github/workflows/ci.yml` — replace single
+  `apple` job with `apple-slice` (matrix over `iosArm64`,
+  `iosSimulatorArm64`, `macosArm64`) and `apple-finalize` (downloads
+  slice `.framework`s, merges via `xcodebuild -create-xcframework`,
+  verifies headers, uploads `Prism.xcframework`, runs xcodegen + iOS
+  demo xcodebuild).
+- 2026-05-08T19:38-0700 `devlog/plans/000024-01-parallel-apple-slices.md`
+  — design doc for the split.
+
+## Decisions
+
+- 2026-05-08T19:38-0700 Three matrix slices (iosArm64,
+  iosSimulatorArm64, macosArm64) rather than two (combine the two iOS
+  slices into one runner). Reasoning: the dominant cost is K/N link of
+  the iOS slices specifically; combining them defeats the parallelism
+  win. macosArm64 has no XCFramework participation but it does host
+  `macosArm64Test` and `prism-native` macOS dylib, which today share
+  the same Gradle invocation as the iOS work — moving them onto their
+  own runner removes them from the critical path of the iOS slice.
+- 2026-05-08T19:38-0700 Merge XCFrameworks with raw `xcodebuild
+  -create-xcframework` in the finalize job instead of running
+  `assemblePrismDebugXCFramework` after staging artifacts. Reasoning:
+  the assemble Gradle task would re-run K/N link tasks (or fail their
+  up-to-date checks) on the finalize runner because the slice
+  `.framework`s come from a different worktree. Bypassing Gradle in
+  finalize keeps the merge purely IO + plist generation.
+- 2026-05-08T19:38-0700 Finalize job does not install Gradle / wgpu4k /
+  K/N toolchain. It only needs xcodegen + xcodebuild.
+- 2026-05-08T19:38-0700 Slice artifacts uploaded as raw `.framework`
+  directories (one artifact per slice). `actions/upload-artifact@v4`
+  zips these but preserves the directory tree on download. Static
+  frameworks have no symlinks so the round-trip should be safe.
+- 2026-05-08T19:38-0700 Each slice keeps the existing K/N toolchain
+  cache (`~/.konan` keyed on Kotlin version). All three slice runners
+  hit the same GHA cache entry → single populate, three readers.
+
+## Issues
+
+- Outstanding: first push will validate that `actions/upload-artifact`
+  preserves the framework tree well enough that `xcodebuild
+  -create-xcframework` accepts it. If the round-trip drops bundle
+  metadata (e.g. `Info.plist`, `Modules/module.modulemap`), the merge
+  will fail and the slice upload step needs `tar` packaging.
+
+## Commits
+
+- HEAD — ci: parallelize Apple XCFramework slices

--- a/devlog/plans/000024-01-parallel-apple-slices.md
+++ b/devlog/plans/000024-01-parallel-apple-slices.md
@@ -1,0 +1,158 @@
+# Plan: parallelize Apple XCFramework slices in CI
+
+## Thinking
+
+The `Apple Targets` CI job today runs a single Gradle invocation that
+serially builds:
+
+```
+iosSimulatorArm64Test
+macosArm64Test
+:prism-demo-core:assemblePrismDemoDebugXCFramework
+:prism-ios:assemblePrismDebugXCFramework
+:prism-native:linkDebugSharedIosSimulatorArm64
+:prism-native:linkDebugSharedMacosArm64
+```
+
+Recent successful run (24959988333) shows that "Apple native tests +
+XCFrameworks" step takes **~14m** out of a ~17m total job. The dominant
+cost is Kotlin/Native link for the static frameworks — each XCFramework
+has 10+ exported modules.
+
+`org.gradle.parallel=true` is already set, but K/N link tasks for
+different Apple slices (iosArm64 vs iosSimulatorArm64) live in the same
+module (`prism-ios`, `prism-demo-core`) and historically don't parallelize
+well within a single Gradle invocation due to memory pressure (4 GB
+heap) and historical K/N compiler-singleton state.
+
+The XCFramework structure is just a directory of per-slice
+`.framework`s plus an `Info.plist`. `xcodebuild -create-xcframework
+-framework <slice1> -framework <slice2> -output Foo.xcframework`
+produces an identical artifact. So we can build each slice's `.framework`
+on its own runner and merge them in a follow-up job — the user's
+preferred approach.
+
+Verified slice-level Gradle task names by listing `:prism-ios:tasks
+--all`:
+
+- `:prism-ios:linkDebugFrameworkIosArm64`
+- `:prism-ios:linkDebugFrameworkIosSimulatorArm64`
+- `:prism-demo-core:linkDebugFrameworkIosArm64`
+- `:prism-demo-core:linkDebugFrameworkIosSimulatorArm64`
+
+Each produces the per-slice `.framework` directory at
+`<module>/build/bin/<target>/debugFramework/<Name>.framework/`.
+
+The `prism-ios-demo` Xcode project (in `project.yml`) references
+`prism-demo-core/build/XCFrameworks/debug/PrismDemo.xcframework`. So
+the finalize job must place the merged XCFramework at exactly that
+path before the iOS demo build step runs.
+
+### Trade-off
+
+- **Wall clock:** matrix slices run in parallel, max(slice times) +
+  finalize merge ≈ 7-9 min vs the current 14 min Gradle step. Finalize
+  job adds ~5 min for the iOS demo build (already in current job). New
+  total ≈ 12-15 min vs current 17 min.
+- **Cost:** 3 macOS runners during the slice phase + 1 macOS runner for
+  finalize = 4 macOS-minute streams instead of 1. macOS runners are
+  10× the linux rate; net macOS-minute spend per CI run is ~3-4×.
+- The user explicitly asked for the slice-then-merge approach and is
+  already aware of CI cost (recent commit `7e2afaf` reduced cache
+  restore time).
+
+### Design
+
+Three jobs replace the existing `apple` job:
+
+```
+apple-slice  (matrix: target ∈ {iosArm64, iosSimulatorArm64, macosArm64})
+   │
+   └─► apple-finalize (needs: apple-slice)
+         (assembles XCFrameworks, runs iOS demo build)
+```
+
+Per-slice tasks:
+
+- **iosArm64**:
+  `:prism-ios:linkDebugFrameworkIosArm64`,
+  `:prism-demo-core:linkDebugFrameworkIosArm64`
+- **iosSimulatorArm64**:
+  `:prism-ios:linkDebugFrameworkIosSimulatorArm64`,
+  `:prism-demo-core:linkDebugFrameworkIosSimulatorArm64`,
+  `:prism-native:linkDebugSharedIosSimulatorArm64`,
+  `iosSimulatorArm64Test` (multi-project umbrella)
+- **macosArm64**:
+  `:prism-native:linkDebugSharedMacosArm64`,
+  `macosArm64Test`
+
+Each slice job uploads:
+
+- `prism-ios/build/bin/<target>/debugFramework/Prism.framework/`
+- `prism-demo-core/build/bin/<target>/debugFramework/PrismDemo.framework/`
+- (sim only) `prism-native/build/bin/iosSimulatorArm64/debugShared/`
+- (mac only) `prism-native/build/bin/macosArm64/debugShared/`
+
+Finalize job:
+
+1. Downloads all artifacts.
+2. Reconstructs the per-target `.framework` paths under
+   `<module>/build/bin/<target>/debugFramework/`.
+3. Calls `xcodebuild -create-xcframework -framework iosArm64.framework
+   -framework iosSimulatorArm64.framework -output
+   <module>/build/XCFrameworks/debug/<Name>.xcframework` for both
+   `Prism` and `PrismDemo`.
+4. Runs the existing header-verification logic against the merged
+   `Prism.xcframework`.
+5. Uploads `Prism-debug.xcframework`.
+6. Runs xcodegen + xcodebuild for `prism-ios-demo` against the merged
+   `PrismDemo.xcframework`.
+
+The finalize job does **not** need wgpu4k or Gradle setup because it
+doesn't invoke Gradle — only `xcodebuild` and `xcodegen`.
+
+### Risks / unknowns
+
+- The K/N link task may emit additional output files (e.g. `Headers/`,
+  `Modules/`, `Resources/`) inside the per-slice `.framework`. We need
+  to upload the entire framework directory tree and preserve symlinks,
+  not just the binary. `actions/upload-artifact@v4` preserves the tree
+  but flattens symlinks. Static frameworks shouldn't have symlinks
+  (those are a dynamic-framework quirk), so this should be fine — but
+  worth verifying on the first run.
+- `iosSimulatorArm64Test` and `macosArm64Test` are aggregator tasks
+  spanning all modules. If any module has its target-specific test
+  fail, that slice job fails. Same as today, just split across runners.
+- Configuration cache: each matrix runner has its own gradle/cache.
+  Cache key is keyed on the same Kotlin/Native version, so all runners
+  share the K/N toolchain cache. The Gradle home cache is
+  per-runner-OS so all three macOS runners share via GHA.
+
+## Plan
+
+1. Refactor `.github/workflows/ci.yml`: replace the `apple` job with
+   `apple-slice` (matrix) + `apple-finalize`.
+2. In `apple-slice`:
+   - Reuse the current setup steps (JDKs, Gradle, K/N toolchain cache,
+     wgpu4k action).
+   - Use a `case`/`if` block on `matrix.target` to invoke the right
+     Gradle tasks per slice.
+   - Upload the per-slice `.framework` directories (and `prism-native`
+     dylibs where applicable) as artifacts named
+     `apple-slice-<target>`.
+3. In `apple-finalize`:
+   - macos-26 runner.
+   - Download all `apple-slice-*` artifacts.
+   - Re-stage the framework directories under
+     `<module>/build/bin/<target>/debugFramework/` so paths match what
+     `xcodebuild -create-xcframework` expects.
+   - Run `xcodebuild -create-xcframework` for `Prism` and `PrismDemo`.
+   - Reuse the existing "Verify XCFramework headers" step.
+   - Reuse the existing "Upload Prism XCFramework" step.
+   - Reuse the existing xcodegen / iOS demo steps.
+4. Drop `--configuration-cache` and `-Pkotlin.native.parallelThreads=3`
+   tuning where no longer applicable; keep on slice jobs that still run
+   Gradle.
+5. Verify on a draft PR — all three slice jobs and the finalize job
+   pass; merged XCFramework artifact looks identical to today's.
+6. After merge, monitor wall-clock numbers in step summary.


### PR DESCRIPTION
The `Apple Targets` job currently builds `iosArm64`, `iosSimulatorArm64`, and `macosArm64` sequentially in a single Gradle invocation. The Kotlin/Native link step dominates the runtime (~14m of a 17m job — see [run 24959988333](https://github.com/hyeons-lab/prism/actions/runs/24959988333)).

Split into a per-slice matrix job that compiles each target on its own macOS runner, then a finalize job that downloads the per-slice `.framework` directories and merges them into `Prism.xcframework` and `PrismDemo.xcframework` via `xcodebuild -create-xcframework`. The finalize job also handles the existing header verification, XCFramework upload, and iOS demo build.

`macosArm64` doesn't contribute to any XCFramework but its slice job still runs `macosArm64Test` and `:prism-native:linkDebugSharedMacosArm64` in parallel with the iOS slices, removing it from the iOS critical path.

**Trade-off:** ~3-4× macOS-runner-minutes per CI run for ~5min of wall-clock savings. Wall-clock target ~12m vs current 17m.

## Test plan
- [ ] All three `Apple Slice (...)` matrix jobs pass.
- [ ] `Apple Finalize` produces `Prism.xcframework` with both `ios-arm64` and `ios-arm64-simulator` slices (existing header verification step covers this).
- [ ] iOS demo build (`xcodebuild -scheme PrismiOSDemo`) succeeds against the merged `PrismDemo.xcframework`.
- [ ] Compare wall-clock against baseline run 24959988333 (~17m) — target ≤13m.
- [ ] Confirm `Prism-debug.xcframework` artifact uploaded by `apple-finalize` is byte-equivalent to today's artifact (or at least functionally equivalent — `xcodebuild -create-xcframework` may regenerate Info.plist).