### PR TITLE
fix(renderer): select a supported surface alpha mode

### DIFF
--- a/devlog/000025-fix-android-surface-alpha-mode.md
+++ b/devlog/000025-fix-android-surface-alpha-mode.md
@@ -1,0 +1,52 @@
+# 000025 — fix/android-surface-alpha-mode
+
+**Agent:** Claude (claude-opus-4-8) @ prism branch fix/android-surface-alpha-mode
+
+## Intent
+
+`WgpuRenderer.initialize` hardcodes `CompositeAlphaMode.Opaque` when configuring the surface. On
+Android/Vulkan many surfaces advertise only `[Inherit, Auto]` and never `Opaque`. wgpu treats
+configuring a surface with an unsupported alpha mode as a **fatal (aborting) error**, so the app
+crashes natively in `wgpuSurfaceConfigure`. Pick an alpha mode the surface actually supports.
+
+## Research & Discoveries
+
+- Reproduced on a Pixel 10 Pro Fold (Android 16, arm64, Vulkan via wgpu4k) running both the stock
+  `prism-android-demo` and a downstream app. Native crash backtrace:
+  `wgpuSurfaceConfigure` → `wgpu_native::handle_error_fatal` → `std::process::abort`, called from
+  `WgpuRenderer.initialize` → `Engine.initialize` → `createGltfDemoScene`.
+- wgpu4k logs the cause at surface creation:
+  `io.ygdrasil.webgpu.Surface_native - supportedAlphaMode: [Inherit, Auto]`
+  (and `supportedTextureFormats: [RGBA8UnormSrgb, RGBA8Unorm, RGBA16Float, RGB10A2Unorm]`).
+- `io.ygdrasil.webgpu.Surface` exposes `supportedAlphaMode: Set<CompositeAlphaMode>` — exactly what's
+  needed to choose a valid mode at runtime.
+
+## What Changed
+
+- 2026-06-07T13:05-07:00 prism-renderer/.../WgpuRenderer.kt — replace the hardcoded
+  `CompositeAlphaMode.Opaque` with `chooseAlphaMode(wgpuContext.surface.supportedAlphaMode)`. Added
+  `internal fun chooseAlphaMode(...)`: prefers Opaque (desktop/Metal), then Inherit, then Auto, then
+  any supported mode. Keeps existing desktop behavior; fixes Android.
+- 2026-06-07T13:05-07:00 (no unit test added) — verified on-device instead; see Issues.
+
+## Decisions
+
+- 2026-06-07T13:05-07:00 Prefer Opaque-then-Inherit-then-Auto rather than always Auto — preserves the
+  prior, intentional Opaque behavior wherever the platform supports it (desktop/Metal) and only
+  diverges where Opaque is unavailable. Reasoning: minimize behavioral change on already-working
+  platforms while unblocking Android.
+- 2026-06-07T13:05-07:00 Helper is a pure `internal` top-level function so it's unit-testable in
+  commonTest without a GPU/device.
+
+## Issues
+
+- Root-caused by reproducing on the stock demo first, ruling out downstream app misconfiguration.
+- Tried adding `AlphaModeTest` in commonTest but it failed with `UnsupportedClassVersionError`:
+  `io.ygdrasil.webgpu.CompositeAlphaMode` is compiled to class version 69 (Java 25), while the
+  `jvmTest` runner resolves to an older JDK. No existing prism commonTest references `io.ygdrasil`
+  runtime types — that's the de-facto convention. Removed the test; the fix is verified on-device
+  (Pixel 10 Pro Fold: pre-fix native crash → post-fix renders) and the logic is a 4-branch selector.
+
+## Commits
+
+- HEAD — fix(renderer): select a supported surface alpha mode (fixes Android Vulkan crash)

--- a/devlog/000025-fix-android-surface-alpha-mode.md
+++ b/devlog/000025-fix-android-surface-alpha-mode.md
@@ -37,6 +37,12 @@ crashes natively in `wgpuSurfaceConfigure`. Pick an alpha mode the surface actua
   platforms while unblocking Android.
 - 2026-06-07T13:05-07:00 Helper is a pure `internal` top-level function so it's unit-testable in
   commonTest without a GPU/device.
+- 2026-06-07T20:15-07:00 (PR review) `chooseAlphaMode` now `require`s a non-empty `supported` set and
+  drops the `?: Opaque` fallback. Reasoning: the empty-set branch returned `Opaque`, contradicting the
+  function's own "returned value is always a member of supported" contract and risking the same native
+  abort on a surface that doesn't support `Opaque`. A configured surface always advertises ≥1 mode, so
+  an empty set is a programming/driver error — fail fast with a clear message instead of returning an
+  unsupported default. Addresses Copilot review comment on WgpuRenderer.kt.
 
 ## Issues
 
@@ -49,4 +55,5 @@ crashes natively in `wgpuSurfaceConfigure`. Pick an alpha mode the surface actua
 
 ## Commits
 
-- HEAD — fix(renderer): select a supported surface alpha mode (fixes Android Vulkan crash)
+- f022333 — fix(renderer): select a supported surface alpha mode (fixes Android Vulkan crash)
+- HEAD — fix(renderer): fail fast when surface advertises no alpha modes (PR review)

--- a/devlog/plans/000025-01-android-surface-alpha-mode.md
+++ b/devlog/plans/000025-01-android-surface-alpha-mode.md
@@ -1,0 +1,25 @@
+# 000025-01 — Android surface alpha mode
+
+## Thinking
+
+The Android/Vulkan surface on a Pixel 10 Pro Fold reports `supportedAlphaMode: [Inherit, Auto]`.
+`WgpuRenderer.initialize` configures the surface with `CompositeAlphaMode.Opaque`, which is not in
+that set. wgpu's `wgpuSurfaceConfigure` aborts the process on an unsupported alpha mode (it's a
+fatal error, not a recoverable one), so there's no try/catch escape — we must pass a supported value.
+
+`io.ygdrasil.webgpu.Surface` already exposes `supportedAlphaMode: Set<CompositeAlphaMode>`, so the
+renderer can query and choose at runtime. We want to keep the previous Opaque behavior on platforms
+that support it (desktop/Metal) to avoid any compositing/perf change there, and only fall back where
+necessary.
+
+## Plan
+
+1. In `WgpuRenderer.initialize`, replace `val alphaMode = CompositeAlphaMode.Opaque` with
+   `chooseAlphaMode(wgpuContext.surface.supportedAlphaMode)`.
+2. Add `internal fun chooseAlphaMode(supported): CompositeAlphaMode` (top-level, same file):
+   Opaque → Inherit → Auto → first supported → Opaque (defensive default).
+3. Add `AlphaModeTest` in `prism-renderer/commonTest` covering the preference order and the observed
+   `[Inherit, Auto]` Android case.
+4. `./gradlew ktfmtFormat` then `./gradlew ktfmtCheck detektJvmMain jvmTest`.
+5. Commit, push, open draft PR. Verify on-device by rebuilding a downstream Android app against this
+   branch.

--- a/prism-renderer/src/commonMain/kotlin/com/hyeonslab/prism/renderer/WgpuRenderer.kt
+++ b/prism-renderer/src/commonMain/kotlin/com/hyeonslab/prism/renderer/WgpuRenderer.kt
@@ -1556,12 +1556,20 @@ class WgpuRenderer(
  * never `Opaque`. Falls back to any supported mode.
  *
  * wgpu treats configuring a surface with an unsupported alpha mode as a fatal (aborting) error, so
- * the returned value must always be a member of [supported].
+ * the returned value is always a member of [supported]. A configured surface always advertises at
+ * least one mode; [supported] being empty is a programming/driver error, so we fail fast with a
+ * clear message rather than return an unsupported default that would re-trigger the native abort.
+ *
+ * @throws IllegalArgumentException if [supported] is empty.
  */
-internal fun chooseAlphaMode(supported: Set<CompositeAlphaMode>): CompositeAlphaMode =
-  when {
+internal fun chooseAlphaMode(supported: Set<CompositeAlphaMode>): CompositeAlphaMode {
+  require(supported.isNotEmpty()) {
+    "Surface advertised no supported composite alpha modes; cannot configure surface."
+  }
+  return when {
     CompositeAlphaMode.Opaque in supported -> CompositeAlphaMode.Opaque
     CompositeAlphaMode.Inherit in supported -> CompositeAlphaMode.Inherit
     CompositeAlphaMode.Auto in supported -> CompositeAlphaMode.Auto
-    else -> supported.firstOrNull() ?: CompositeAlphaMode.Opaque
+    else -> supported.first()
   }
+}

--- a/prism-renderer/src/commonMain/kotlin/com/hyeonslab/prism/renderer/WgpuRenderer.kt
+++ b/prism-renderer/src/commonMain/kotlin/com/hyeonslab/prism/renderer/WgpuRenderer.kt
@@ -199,13 +199,12 @@ class WgpuRenderer(
   override fun initialize(engine: Engine) {
     if (!surfacePreConfigured) {
       val format = renderingContext.textureFormat
-      val alphaMode = CompositeAlphaMode.Opaque
       wgpuContext.surface.configure(
         SurfaceConfiguration(
           device = device,
           format = format,
           usage = GPUTextureUsage.RenderAttachment,
-          alphaMode = alphaMode,
+          alphaMode = chooseAlphaMode(wgpuContext.surface.supportedAlphaMode),
         )
       )
     }
@@ -1549,3 +1548,20 @@ class WgpuRenderer(
       TextureFormat.RGBA16_FLOAT -> GPUTextureFormat.RGBA16Float
     }
 }
+
+/**
+ * Picks a surface composite-alpha mode that the device actually supports. Prefers
+ * [CompositeAlphaMode.Opaque] (desktop/Metal), then [CompositeAlphaMode.Inherit], then
+ * [CompositeAlphaMode.Auto] — Android/Vulkan surfaces commonly advertise only `[Inherit, Auto]` and
+ * never `Opaque`. Falls back to any supported mode.
+ *
+ * wgpu treats configuring a surface with an unsupported alpha mode as a fatal (aborting) error, so
+ * the returned value must always be a member of [supported].
+ */
+internal fun chooseAlphaMode(supported: Set<CompositeAlphaMode>): CompositeAlphaMode =
+  when {
+    CompositeAlphaMode.Opaque in supported -> CompositeAlphaMode.Opaque
+    CompositeAlphaMode.Inherit in supported -> CompositeAlphaMode.Inherit
+    CompositeAlphaMode.Auto in supported -> CompositeAlphaMode.Auto
+    else -> supported.firstOrNull() ?: CompositeAlphaMode.Opaque
+  }


### PR DESCRIPTION
## Problem

`WgpuRenderer.initialize` hardcodes `CompositeAlphaMode.Opaque` when configuring the surface. On Android/Vulkan many surfaces advertise only `[Inherit, Auto]` and never `Opaque`. wgpu treats configuring a surface with an unsupported alpha mode as a **fatal (aborting) error**, so the app crashes natively in `wgpuSurfaceConfigure` during init.

Reproduced on a **Pixel 10 Pro Fold (Android 16, arm64)** with the stock `prism-android-demo`:

```
wgpuSurfaceConfigure -> wgpu_native::handle_error_fatal -> std::process::abort
  <- WgpuRenderer.initialize <- Engine.initialize <- createGltfDemoScene
io.ygdrasil.webgpu.Surface_native - supportedAlphaMode: [Inherit, Auto]
```

## Fix

Query `wgpuContext.surface.supportedAlphaMode` and pick a supported mode via a new internal `chooseAlphaMode()`: `Opaque → Inherit → Auto → any`. This preserves the prior `Opaque` behavior on desktop/Metal and fixes the crash on Android/Vulkan.

## Verification

- Repro'd the native crash on the stock `prism-android-demo` (Pixel 10 Pro Fold), then confirmed the same device renders after the fix.
- `./gradlew ktfmtCheck detektJvmMain jvmTest` — green (268 existing tests unaffected).
- No unit test added for `chooseAlphaMode`: `io.ygdrasil.webgpu.CompositeAlphaMode` is compiled to class version 69 (Java 25) and the `jvmTest` runner resolves to an older JDK, so referencing it from commonTest fails with `UnsupportedClassVersionError` — matching the existing convention that prism commonTest never references wgpu4k runtime types.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyeons-lab/codesmith/prism/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783455209&installation_id=134193259&pr_number=54&repository=hyeons-lab%2Fprism&return_to=https%3A%2F%2Fgithub.com%2Fhyeons-lab%2Fprism%2Fpull%2F54&signature=4e16e23c4d20cfad49ba9c5f0a7a87583102a6645b2ca78ae7c6eb4fe69134ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->