### PR TITLE
feat(audio): add Android AudioEngine (SoundPool + MediaPlayer)

### DIFF
--- a/devlog/000026-feat-android-audio-engine.md
+++ b/devlog/000026-feat-android-audio-engine.md
@@ -38,6 +38,16 @@ game (voice-driven kids' shooter) that needs pop/hit/chime SFX.
   last requested `Music.volume` per path in `musicVolumes` and apply `track * master` in both
   `playMusic` and `setMasterVolume` (previously master overwrote every player, losing per-track
   levels). `musicVolumes` is cleared in `stopMusic` and `shutdown` so it doesn't leak stale state.
+- 2026-06-07T20:41-07:00 (PR review, round 2) Record SFX load failures. A non-zero async
+  load-complete status (or `load()==0`) now flags the path in `failedPaths` and drops it from
+  `soundIds`. `playSound` reports a permanent "failed to load" instead of warning "still loading"
+  forever, and `loadSound` retries the path (clearing the flag) since it's no longer in `soundIds`.
+- 2026-06-07T20:41-07:00 (PR review, round 2) Track all active *looping* streams per path in a list
+  so `stopSound` stops every one (previously only the most recent stream id was kept, so repeated
+  looping plays leaked streams that could never be stopped). One-shot streams are deliberately not
+  tracked: they self-terminate, SoundPool gives no per-stream completion callback, and it recycles
+  stream ids — so a retained one-shot id can go stale and `stop()` the wrong stream. `failedPaths`
+  is cleared in `shutdown`.
 
 ## Issues
 
@@ -47,4 +57,5 @@ game (voice-driven kids' shooter) that needs pop/hit/chime SFX.
 ## Commits
 
 - bfa9c45 — feat(audio): add Android AudioEngine (SoundPool SFX + MediaPlayer music)
-- HEAD — fix(audio): gate SFX on load, harden MediaPlayer + per-track volume (PR review)
+- 6ae132f — fix(audio): gate SFX on load, harden MediaPlayer + per-track volume (PR review)
+- HEAD — fix(audio): record SFX load failures and track looping streams (PR review)

--- a/devlog/000026-feat-android-audio-engine.md
+++ b/devlog/000026-feat-android-audio-engine.md
@@ -1,0 +1,37 @@
+# 000026 — feat/android-audio-engine
+
+**Agent:** Claude (claude-opus-4-8) @ prism branch feat/android-audio-engine
+
+## Intent
+
+`prism-audio` defines the `AudioEngine` interface but only ships `StubAudioEngine` (no-op). Provide a
+real Android implementation so apps get sound effects and music. Motivated by a downstream tablet
+game (voice-driven kids' shooter) that needs pop/hit/chime SFX.
+
+## What Changed
+
+- 2026-06-07T14:11-07:00 prism-audio/src/androidMain/.../AndroidAudioEngine.kt — new Android
+  `AudioEngine` actual: `SoundPool` (USAGE_GAME) for low-latency polyphonic SFX, `MediaPlayer` for
+  music. Loads from app `assets/` by relative path; tracks sample ids and active stream ids (so
+  `stopSound` works); per-path MediaPlayer map for play/pause/stop; master volume applied to both.
+  This adds the module's first `androidMain` source set.
+
+## Decisions
+
+- 2026-06-07T14:11-07:00 SoundPool for SFX, MediaPlayer for music — the standard Android split:
+  SoundPool is built for short, frequent, overlapping clips with minimal latency; MediaPlayer suits
+  longer streamed music. Sounds load asynchronously, so callers preload (documented on the class).
+- 2026-06-07T14:11-07:00 Constructor takes a `Context` (retains `applicationContext`) — required to
+  read assets and build the players. `StubAudioEngine` remains the default for other platforms; no
+  behavior change to existing demos.
+- 2026-06-07T14:11-07:00 Devlog numbered 000026 (not 000025) to avoid colliding with the in-flight
+  fix/android-surface-alpha-mode branch (PR #54) which already uses 000025. Renumber on merge if needed.
+
+## Issues
+
+- None. `:prism-audio:compileAndroidMain` is warning-clean (module sets allWarningsAsErrors); full
+  gate `ktfmtCheck detektJvmMain jvmTest` passes.
+
+## Commits
+
+- HEAD — feat(audio): add Android AudioEngine (SoundPool SFX + MediaPlayer music)

--- a/devlog/000026-feat-android-audio-engine.md
+++ b/devlog/000026-feat-android-audio-engine.md
@@ -48,6 +48,13 @@ game (voice-driven kids' shooter) that needs pop/hit/chime SFX.
   tracked: they self-terminate, SoundPool gives no per-stream completion callback, and it recycles
   stream ids — so a retained one-shot id can go stale and `stop()` the wrong stream. `failedPaths`
   is cleared in `shutdown`.
+- 2026-06-07T21:10-07:00 (PR review, round 3) `setMasterVolume` now also re-applies `base * master`
+  to live looping SFX streams (via `SoundPool.setVolume`), not just MediaPlayers — so master changes
+  take effect on already-playing loops without a replay. `activeStreams` entries became
+  `ActiveStream(streamId, baseVolume)` to retain each stream's per-track volume for this.
+- 2026-06-07T21:10-07:00 (PR review, round 3) Split the load-failure log's optional " for <path>"
+  suffix into a local so the statement fits the 100-col ktfmt width and drops the nested
+  interpolation.
 
 ## Issues
 
@@ -58,4 +65,5 @@ game (voice-driven kids' shooter) that needs pop/hit/chime SFX.
 
 - bfa9c45 — feat(audio): add Android AudioEngine (SoundPool SFX + MediaPlayer music)
 - 6ae132f — fix(audio): gate SFX on load, harden MediaPlayer + per-track volume (PR review)
-- HEAD — fix(audio): record SFX load failures and track looping streams (PR review)
+- 770bae5 — fix(audio): record SFX load failures and track looping streams (PR review)
+- HEAD — fix(audio): apply master volume to live SFX streams, shorten log (PR review)

--- a/devlog/000026-feat-android-audio-engine.md
+++ b/devlog/000026-feat-android-audio-engine.md
@@ -26,6 +26,18 @@ game (voice-driven kids' shooter) that needs pop/hit/chime SFX.
   behavior change to existing demos.
 - 2026-06-07T14:11-07:00 Devlog numbered 000026 (not 000025) to avoid colliding with the in-flight
   fix/android-surface-alpha-mode branch (PR #54) which already uses 000025. Renumber on merge if needed.
+- 2026-06-07T20:31-07:00 (PR review) Gate SFX playback on load completion. SoundPool.load is async,
+  so `playSound` now skips (with a warning) until the sample id appears in a `readySamples` set
+  populated by `setOnLoadCompleteListener`. `SoundPool.load`/`play` returning 0 are treated as
+  failures (not stored / logged) rather than silently succeeding.
+- 2026-06-07T20:31-07:00 (PR review) Never cache a half-initialized MediaPlayer: `playMusic` builds
+  the player in `prepareMusicPlayer`, which only inserts into `musicPlayers` after `prepare()`
+  succeeds and releases on failure. `isLooping` is set every play so a later call with a different
+  `Music.loop` takes effect.
+- 2026-06-07T20:31-07:00 (PR review) Preserve per-track music volume across master changes: store the
+  last requested `Music.volume` per path in `musicVolumes` and apply `track * master` in both
+  `playMusic` and `setMasterVolume` (previously master overwrote every player, losing per-track
+  levels). `musicVolumes` is cleared in `stopMusic` and `shutdown` so it doesn't leak stale state.
 
 ## Issues
 
@@ -34,4 +46,5 @@ game (voice-driven kids' shooter) that needs pop/hit/chime SFX.
 
 ## Commits
 
-- HEAD — feat(audio): add Android AudioEngine (SoundPool SFX + MediaPlayer music)
+- bfa9c45 — feat(audio): add Android AudioEngine (SoundPool SFX + MediaPlayer music)
+- HEAD — fix(audio): gate SFX on load, harden MediaPlayer + per-track volume (PR review)

--- a/prism-audio/src/androidMain/kotlin/com/hyeonslab/prism/audio/AndroidAudioEngine.kt
+++ b/prism-audio/src/androidMain/kotlin/com/hyeonslab/prism/audio/AndroidAudioEngine.kt
@@ -38,8 +38,11 @@ class AndroidAudioEngine(context: Context, maxStreams: Int = 8) : AudioEngine {
       )
       .build()
 
-  /** Asset path -> SoundPool sample id (only populated for successful [SoundPool.load] calls). */
-  private val soundIds: MutableMap<String, Int> = mutableMapOf()
+  /**
+   * Asset path -> SoundPool sample id. Concurrent because the load-complete callback (possibly on
+   * another thread) removes an entry when its load fails so [loadSound] can retry the path.
+   */
+  private val soundIds: MutableMap<String, Int> = ConcurrentHashMap()
 
   /**
    * Sample ids that have finished loading successfully. Written from the SoundPool load-complete
@@ -47,8 +50,20 @@ class AndroidAudioEngine(context: Context, maxStreams: Int = 8) : AudioEngine {
    */
   private val readySamples: MutableSet<Int> = ConcurrentHashMap.newKeySet()
 
-  /** Asset path -> most recent active stream id (for [stopSound]). */
-  private val activeStreams: MutableMap<String, Int> = mutableMapOf()
+  /**
+   * Paths whose most recent load attempt failed (sync `load()==0` or async non-zero status), so
+   * [playSound] can report a permanent failure instead of warning "still loading" forever. Cleared
+   * when [loadSound] retries the path.
+   */
+  private val failedPaths: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+  /**
+   * Asset path -> active *looping* stream ids (for [stopSound]). One-shot streams are intentionally
+   * not tracked: they stop themselves, SoundPool gives no per-stream completion callback, and it
+   * recycles stream ids — so a retained one-shot id can go stale and later [SoundPool.stop] the
+   * wrong stream. Only looping streams persist and need explicit stopping.
+   */
+  private val activeStreams: MutableMap<String, MutableList<Int>> = mutableMapOf()
 
   /** Asset path -> MediaPlayer for music. Only holds successfully-prepared players. */
   private val musicPlayers: MutableMap<String, MediaPlayer> = mutableMapOf()
@@ -63,13 +78,21 @@ class AndroidAudioEngine(context: Context, maxStreams: Int = 8) : AudioEngine {
       if (status == 0) {
         readySamples.add(sampleId)
       } else {
-        logger.e { "SoundPool failed to load sampleId=$sampleId (status=$status)" }
+        // Drop the path->id mapping and flag it failed so playSound stops saying "still loading"
+        // and loadSound can retry the path.
+        val path = soundIds.entries.firstOrNull { it.value == sampleId }?.key
+        if (path != null) {
+          soundIds.remove(path)
+          failedPaths.add(path)
+        }
+        logger.e { "SoundPool failed to load sampleId=$sampleId (status=$status)${path?.let { " for $it" } ?: ""}" }
       }
     }
   }
 
   override fun loadSound(path: String): Sound {
     if (!soundIds.containsKey(path)) {
+      failedPaths.remove(path) // retrying — clear any prior failure flag
       try {
         appContext.assets.openFd(path).use { afd ->
           // load() returns 0 on failure; only record real sample ids so playSound can trust the map.
@@ -77,10 +100,12 @@ class AndroidAudioEngine(context: Context, maxStreams: Int = 8) : AudioEngine {
           if (sampleId != 0) {
             soundIds[path] = sampleId
           } else {
+            failedPaths.add(path)
             logger.e { "SoundPool.load returned 0 (failed) for: $path" }
           }
         }
       } catch (e: Exception) {
+        failedPaths.add(path)
         logger.e(e) { "Failed to load sound: $path" }
       }
     }
@@ -88,6 +113,10 @@ class AndroidAudioEngine(context: Context, maxStreams: Int = 8) : AudioEngine {
   }
 
   override fun playSound(sound: Sound) {
+    if (sound.path in failedPaths) {
+      logger.w { "playSound: sound failed to load: ${sound.path}" }
+      return
+    }
     val sampleId = soundIds[sound.path]
     if (sampleId == null) {
       logger.w { "playSound: sound not loaded: ${sound.path}" }
@@ -100,15 +129,16 @@ class AndroidAudioEngine(context: Context, maxStreams: Int = 8) : AudioEngine {
     val volume = (sound.volume * masterVolume).coerceIn(0f, 1f)
     val loop = if (sound.loop) -1 else 0
     val streamId = soundPool.play(sampleId, volume, volume, 1, loop, sound.pitch)
-    if (streamId != 0) {
-      activeStreams[sound.path] = streamId
-    } else {
+    if (streamId == 0) {
       logger.w { "playSound: SoundPool.play returned 0 (not started): ${sound.path}" }
+    } else if (sound.loop) {
+      // Only looping streams are retained (see activeStreams) — one-shots stop themselves.
+      activeStreams.getOrPut(sound.path) { mutableListOf() }.add(streamId)
     }
   }
 
   override fun stopSound(sound: Sound) {
-    activeStreams.remove(sound.path)?.let { soundPool.stop(it) }
+    activeStreams.remove(sound.path)?.forEach { soundPool.stop(it) }
   }
 
   override fun loadMusic(path: String): Music = Music(id = path, path = path)
@@ -176,6 +206,7 @@ class AndroidAudioEngine(context: Context, maxStreams: Int = 8) : AudioEngine {
     soundPool.release()
     soundIds.clear()
     readySamples.clear()
+    failedPaths.clear()
     activeStreams.clear()
     for (mp in musicPlayers.values) {
       runCatching { mp.stop() }

--- a/prism-audio/src/androidMain/kotlin/com/hyeonslab/prism/audio/AndroidAudioEngine.kt
+++ b/prism-audio/src/androidMain/kotlin/com/hyeonslab/prism/audio/AndroidAudioEngine.kt
@@ -57,13 +57,18 @@ class AndroidAudioEngine(context: Context, maxStreams: Int = 8) : AudioEngine {
    */
   private val failedPaths: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
+  /** An active looping SFX stream and the per-track volume it was started with. */
+  private data class ActiveStream(val streamId: Int, val baseVolume: Float)
+
   /**
-   * Asset path -> active *looping* stream ids (for [stopSound]). One-shot streams are intentionally
-   * not tracked: they stop themselves, SoundPool gives no per-stream completion callback, and it
-   * recycles stream ids — so a retained one-shot id can go stale and later [SoundPool.stop] the
-   * wrong stream. Only looping streams persist and need explicit stopping.
+   * Asset path -> active *looping* streams (for [stopSound] and [setMasterVolume]). Each entry keeps
+   * the stream's per-track [ActiveStream.baseVolume] so a master-volume change can re-apply
+   * `base * master` to live streams. One-shot streams are intentionally not tracked: they stop
+   * themselves, SoundPool gives no per-stream completion callback, and it recycles stream ids, so a
+   * retained one-shot id can go stale and later stop/setVolume the wrong stream. Only looping
+   * streams persist and need explicit control.
    */
-  private val activeStreams: MutableMap<String, MutableList<Int>> = mutableMapOf()
+  private val activeStreams: MutableMap<String, MutableList<ActiveStream>> = mutableMapOf()
 
   /** Asset path -> MediaPlayer for music. Only holds successfully-prepared players. */
   private val musicPlayers: MutableMap<String, MediaPlayer> = mutableMapOf()
@@ -85,7 +90,8 @@ class AndroidAudioEngine(context: Context, maxStreams: Int = 8) : AudioEngine {
           soundIds.remove(path)
           failedPaths.add(path)
         }
-        logger.e { "SoundPool failed to load sampleId=$sampleId (status=$status)${path?.let { " for $it" } ?: ""}" }
+        val forPath = if (path != null) " for $path" else ""
+        logger.e { "SoundPool failed to load sampleId=$sampleId (status=$status)$forPath" }
       }
     }
   }
@@ -132,13 +138,15 @@ class AndroidAudioEngine(context: Context, maxStreams: Int = 8) : AudioEngine {
     if (streamId == 0) {
       logger.w { "playSound: SoundPool.play returned 0 (not started): ${sound.path}" }
     } else if (sound.loop) {
-      // Only looping streams are retained (see activeStreams) — one-shots stop themselves.
-      activeStreams.getOrPut(sound.path) { mutableListOf() }.add(streamId)
+      // Only looping streams are retained (see activeStreams); one-shots stop themselves. Keep the
+      // per-track base volume so setMasterVolume can re-apply base * master to the live stream.
+      val stream = ActiveStream(streamId, sound.volume.coerceIn(0f, 1f))
+      activeStreams.getOrPut(sound.path) { mutableListOf() }.add(stream)
     }
   }
 
   override fun stopSound(sound: Sound) {
-    activeStreams.remove(sound.path)?.forEach { soundPool.stop(it) }
+    activeStreams.remove(sound.path)?.forEach { soundPool.stop(it.streamId) }
   }
 
   override fun loadMusic(path: String): Music = Music(id = path, path = path)
@@ -156,7 +164,10 @@ class AndroidAudioEngine(context: Context, maxStreams: Int = 8) : AudioEngine {
       .onFailure { logger.e(it) { "Failed to start music: ${music.path}" } }
   }
 
-  /** Builds and prepares a [MediaPlayer], caching it on success. Returns null (and releases) on failure. */
+  /**
+   * Builds and prepares a [MediaPlayer], caching it on success. Returns null (and releases) on
+   * failure.
+   */
   private fun prepareMusicPlayer(path: String): MediaPlayer? {
     val mp = MediaPlayer()
     return try {
@@ -191,6 +202,13 @@ class AndroidAudioEngine(context: Context, maxStreams: Int = 8) : AudioEngine {
     for ((path, mp) in musicPlayers) {
       val trackVolume = ((musicVolumes[path] ?: 1f) * masterVolume).coerceIn(0f, 1f)
       mp.setVolume(trackVolume, trackVolume)
+    }
+    // Also update live looping SFX streams so master changes take effect without a replay.
+    for (streams in activeStreams.values) {
+      for (stream in streams) {
+        val v = (stream.baseVolume * masterVolume).coerceIn(0f, 1f)
+        soundPool.setVolume(stream.streamId, v, v)
+      }
     }
   }
 

--- a/prism-audio/src/androidMain/kotlin/com/hyeonslab/prism/audio/AndroidAudioEngine.kt
+++ b/prism-audio/src/androidMain/kotlin/com/hyeonslab/prism/audio/AndroidAudioEngine.kt
@@ -7,131 +7,182 @@ import android.media.SoundPool
 import co.touchlab.kermit.Logger
 import com.hyeonslab.prism.core.Engine
 import com.hyeonslab.prism.core.Time
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Android [AudioEngine] backed by [SoundPool] for short sound effects and [MediaPlayer] for music.
  *
- * Sounds and music are loaded from the app's `assets/` by their relative [path]. Sounds load
- * asynchronously, so preload them (e.g. at scene setup) before calling [playSound]. Suitable for
- * games: low-latency, polyphonic SFX plus a single looping music track per path.
+ * Sounds and music are loaded from the app's `assets/` by their relative [path]. SoundPool loads
+ * asynchronously, so preload sounds (e.g. at scene setup) before calling [playSound]: playback is
+ * gated on the sample finishing load and is dropped (with a warning) until then. Suitable for games:
+ * low-latency, polyphonic SFX plus a single looping music track per path.
  *
  * @param context any [Context] (the application context is retained).
  * @param maxStreams maximum number of simultaneous sound effects.
  */
 class AndroidAudioEngine(context: Context, maxStreams: Int = 8) : AudioEngine {
 
-    override val name: String = "Audio"
+  override val name: String = "Audio"
 
-    private val appContext: Context = context.applicationContext
-    private val logger = Logger.withTag("PrismAudio")
+  private val appContext: Context = context.applicationContext
+  private val logger = Logger.withTag("PrismAudio")
 
-    private val soundPool: SoundPool =
-        SoundPool.Builder()
-            .setMaxStreams(maxStreams)
-            .setAudioAttributes(
-                AudioAttributes.Builder()
-                    .setUsage(AudioAttributes.USAGE_GAME)
-                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                    .build()
-            )
-            .build()
+  private val soundPool: SoundPool =
+    SoundPool.Builder()
+      .setMaxStreams(maxStreams)
+      .setAudioAttributes(
+        AudioAttributes.Builder()
+          .setUsage(AudioAttributes.USAGE_GAME)
+          .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+          .build()
+      )
+      .build()
 
-    /** Asset path -> SoundPool sample id. */
-    private val soundIds: MutableMap<String, Int> = mutableMapOf()
+  /** Asset path -> SoundPool sample id (only populated for successful [SoundPool.load] calls). */
+  private val soundIds: MutableMap<String, Int> = mutableMapOf()
 
-    /** Asset path -> most recent active stream id (for [stopSound]). */
-    private val activeStreams: MutableMap<String, Int> = mutableMapOf()
+  /**
+   * Sample ids that have finished loading successfully. Written from the SoundPool load-complete
+   * callback (which may run on a different thread) and read from [playSound], so it is concurrent.
+   */
+  private val readySamples: MutableSet<Int> = ConcurrentHashMap.newKeySet()
 
-    /** Asset path -> MediaPlayer for music. */
-    private val musicPlayers: MutableMap<String, MediaPlayer> = mutableMapOf()
+  /** Asset path -> most recent active stream id (for [stopSound]). */
+  private val activeStreams: MutableMap<String, Int> = mutableMapOf()
 
-    private var masterVolume: Float = 1f
+  /** Asset path -> MediaPlayer for music. Only holds successfully-prepared players. */
+  private val musicPlayers: MutableMap<String, MediaPlayer> = mutableMapOf()
 
-    override fun loadSound(path: String): Sound {
-        if (!soundIds.containsKey(path)) {
-            try {
-                appContext.assets.openFd(path).use { afd ->
-                    soundIds[path] = soundPool.load(afd, 1)
-                }
-            } catch (e: Exception) {
-                logger.e(e) { "Failed to load sound: $path" }
-            }
+  /** Asset path -> last requested per-track music volume, so master changes can re-multiply it. */
+  private val musicVolumes: MutableMap<String, Float> = mutableMapOf()
+
+  private var masterVolume: Float = 1f
+
+  init {
+    soundPool.setOnLoadCompleteListener { _, sampleId, status ->
+      if (status == 0) {
+        readySamples.add(sampleId)
+      } else {
+        logger.e { "SoundPool failed to load sampleId=$sampleId (status=$status)" }
+      }
+    }
+  }
+
+  override fun loadSound(path: String): Sound {
+    if (!soundIds.containsKey(path)) {
+      try {
+        appContext.assets.openFd(path).use { afd ->
+          // load() returns 0 on failure; only record real sample ids so playSound can trust the map.
+          val sampleId = soundPool.load(afd, 1)
+          if (sampleId != 0) {
+            soundIds[path] = sampleId
+          } else {
+            logger.e { "SoundPool.load returned 0 (failed) for: $path" }
+          }
         }
-        return Sound(id = path, path = path)
+      } catch (e: Exception) {
+        logger.e(e) { "Failed to load sound: $path" }
+      }
     }
+    return Sound(id = path, path = path)
+  }
 
-    override fun playSound(sound: Sound) {
-        val sampleId = soundIds[sound.path]
-        if (sampleId == null) {
-            logger.w { "playSound: sound not loaded: ${sound.path}" }
-            return
-        }
-        val volume = (sound.volume * masterVolume).coerceIn(0f, 1f)
-        val loop = if (sound.loop) -1 else 0
-        val streamId = soundPool.play(sampleId, volume, volume, 1, loop, sound.pitch)
-        if (streamId != 0) activeStreams[sound.path] = streamId
+  override fun playSound(sound: Sound) {
+    val sampleId = soundIds[sound.path]
+    if (sampleId == null) {
+      logger.w { "playSound: sound not loaded: ${sound.path}" }
+      return
     }
-
-    override fun stopSound(sound: Sound) {
-        activeStreams.remove(sound.path)?.let { soundPool.stop(it) }
+    if (sampleId !in readySamples) {
+      logger.w { "playSound: sound still loading, skipping: ${sound.path}" }
+      return
     }
-
-    override fun loadMusic(path: String): Music = Music(id = path, path = path)
-
-    override fun playMusic(music: Music) {
-        val player =
-            musicPlayers.getOrPut(music.path) {
-                MediaPlayer().also { mp ->
-                    try {
-                        appContext.assets.openFd(music.path).use { afd ->
-                            mp.setDataSource(afd.fileDescriptor, afd.startOffset, afd.length)
-                        }
-                        mp.isLooping = music.loop
-                        mp.prepare()
-                    } catch (e: Exception) {
-                        logger.e(e) { "Failed to load music: ${music.path}" }
-                    }
-                }
-            }
-        val volume = (music.volume * masterVolume).coerceIn(0f, 1f)
-        player.setVolume(volume, volume)
-        runCatching { player.start() }
-            .onFailure { logger.e(it) { "Failed to start music: ${music.path}" } }
+    val volume = (sound.volume * masterVolume).coerceIn(0f, 1f)
+    val loop = if (sound.loop) -1 else 0
+    val streamId = soundPool.play(sampleId, volume, volume, 1, loop, sound.pitch)
+    if (streamId != 0) {
+      activeStreams[sound.path] = streamId
+    } else {
+      logger.w { "playSound: SoundPool.play returned 0 (not started): ${sound.path}" }
     }
+  }
 
-    override fun pauseMusic(music: Music) {
-        musicPlayers[music.path]?.let { if (it.isPlaying) it.pause() }
-    }
+  override fun stopSound(sound: Sound) {
+    activeStreams.remove(sound.path)?.let { soundPool.stop(it) }
+  }
 
-    override fun stopMusic(music: Music) {
-        musicPlayers.remove(music.path)?.let { mp ->
-            runCatching { mp.stop() }
-            mp.release()
-        }
-    }
+  override fun loadMusic(path: String): Music = Music(id = path, path = path)
 
-    override fun setMasterVolume(volume: Float) {
-        masterVolume = volume.coerceIn(0f, 1f)
-        for (mp in musicPlayers.values) mp.setVolume(masterVolume, masterVolume)
-    }
+  override fun playMusic(music: Music) {
+    // Reuse an already-prepared player; otherwise build one and only cache it on success so a
+    // failed load never leaves a half-initialized MediaPlayer in the map.
+    val player = musicPlayers[music.path] ?: prepareMusicPlayer(music.path) ?: return
+    // Apply looping every play so a later call with a different Music.loop takes effect.
+    player.isLooping = music.loop
+    musicVolumes[music.path] = music.volume
+    val volume = (music.volume * masterVolume).coerceIn(0f, 1f)
+    player.setVolume(volume, volume)
+    runCatching { player.start() }
+      .onFailure { logger.e(it) { "Failed to start music: ${music.path}" } }
+  }
 
-    override fun initialize(engine: Engine) {
-        logger.i { "AndroidAudioEngine initialized" }
+  /** Builds and prepares a [MediaPlayer], caching it on success. Returns null (and releases) on failure. */
+  private fun prepareMusicPlayer(path: String): MediaPlayer? {
+    val mp = MediaPlayer()
+    return try {
+      appContext.assets.openFd(path).use { afd ->
+        mp.setDataSource(afd.fileDescriptor, afd.startOffset, afd.length)
+      }
+      mp.prepare()
+      musicPlayers[path] = mp
+      mp
+    } catch (e: Exception) {
+      logger.e(e) { "Failed to load music: $path" }
+      mp.release()
+      null
     }
+  }
 
-    override fun update(time: Time) {
-        // No per-frame work needed.
-    }
+  override fun pauseMusic(music: Music) {
+    musicPlayers[music.path]?.let { if (it.isPlaying) it.pause() }
+  }
 
-    override fun shutdown() {
-        soundPool.release()
-        soundIds.clear()
-        activeStreams.clear()
-        for (mp in musicPlayers.values) {
-            runCatching { mp.stop() }
-            mp.release()
-        }
-        musicPlayers.clear()
-        logger.i { "AndroidAudioEngine shut down" }
+  override fun stopMusic(music: Music) {
+    musicVolumes.remove(music.path)
+    musicPlayers.remove(music.path)?.let { mp ->
+      runCatching { mp.stop() }
+      mp.release()
     }
+  }
+
+  override fun setMasterVolume(volume: Float) {
+    masterVolume = volume.coerceIn(0f, 1f)
+    // Re-apply as a multiplier on each track's last requested volume, preserving per-track levels.
+    for ((path, mp) in musicPlayers) {
+      val trackVolume = ((musicVolumes[path] ?: 1f) * masterVolume).coerceIn(0f, 1f)
+      mp.setVolume(trackVolume, trackVolume)
+    }
+  }
+
+  override fun initialize(engine: Engine) {
+    logger.i { "AndroidAudioEngine initialized" }
+  }
+
+  override fun update(time: Time) {
+    // No per-frame work needed.
+  }
+
+  override fun shutdown() {
+    soundPool.release()
+    soundIds.clear()
+    readySamples.clear()
+    activeStreams.clear()
+    for (mp in musicPlayers.values) {
+      runCatching { mp.stop() }
+      mp.release()
+    }
+    musicPlayers.clear()
+    musicVolumes.clear()
+    logger.i { "AndroidAudioEngine shut down" }
+  }
 }

--- a/prism-audio/src/androidMain/kotlin/com/hyeonslab/prism/audio/AndroidAudioEngine.kt
+++ b/prism-audio/src/androidMain/kotlin/com/hyeonslab/prism/audio/AndroidAudioEngine.kt
@@ -1,0 +1,137 @@
+package com.hyeonslab.prism.audio
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.MediaPlayer
+import android.media.SoundPool
+import co.touchlab.kermit.Logger
+import com.hyeonslab.prism.core.Engine
+import com.hyeonslab.prism.core.Time
+
+/**
+ * Android [AudioEngine] backed by [SoundPool] for short sound effects and [MediaPlayer] for music.
+ *
+ * Sounds and music are loaded from the app's `assets/` by their relative [path]. Sounds load
+ * asynchronously, so preload them (e.g. at scene setup) before calling [playSound]. Suitable for
+ * games: low-latency, polyphonic SFX plus a single looping music track per path.
+ *
+ * @param context any [Context] (the application context is retained).
+ * @param maxStreams maximum number of simultaneous sound effects.
+ */
+class AndroidAudioEngine(context: Context, maxStreams: Int = 8) : AudioEngine {
+
+    override val name: String = "Audio"
+
+    private val appContext: Context = context.applicationContext
+    private val logger = Logger.withTag("PrismAudio")
+
+    private val soundPool: SoundPool =
+        SoundPool.Builder()
+            .setMaxStreams(maxStreams)
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_GAME)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .build()
+            )
+            .build()
+
+    /** Asset path -> SoundPool sample id. */
+    private val soundIds: MutableMap<String, Int> = mutableMapOf()
+
+    /** Asset path -> most recent active stream id (for [stopSound]). */
+    private val activeStreams: MutableMap<String, Int> = mutableMapOf()
+
+    /** Asset path -> MediaPlayer for music. */
+    private val musicPlayers: MutableMap<String, MediaPlayer> = mutableMapOf()
+
+    private var masterVolume: Float = 1f
+
+    override fun loadSound(path: String): Sound {
+        if (!soundIds.containsKey(path)) {
+            try {
+                appContext.assets.openFd(path).use { afd ->
+                    soundIds[path] = soundPool.load(afd, 1)
+                }
+            } catch (e: Exception) {
+                logger.e(e) { "Failed to load sound: $path" }
+            }
+        }
+        return Sound(id = path, path = path)
+    }
+
+    override fun playSound(sound: Sound) {
+        val sampleId = soundIds[sound.path]
+        if (sampleId == null) {
+            logger.w { "playSound: sound not loaded: ${sound.path}" }
+            return
+        }
+        val volume = (sound.volume * masterVolume).coerceIn(0f, 1f)
+        val loop = if (sound.loop) -1 else 0
+        val streamId = soundPool.play(sampleId, volume, volume, 1, loop, sound.pitch)
+        if (streamId != 0) activeStreams[sound.path] = streamId
+    }
+
+    override fun stopSound(sound: Sound) {
+        activeStreams.remove(sound.path)?.let { soundPool.stop(it) }
+    }
+
+    override fun loadMusic(path: String): Music = Music(id = path, path = path)
+
+    override fun playMusic(music: Music) {
+        val player =
+            musicPlayers.getOrPut(music.path) {
+                MediaPlayer().also { mp ->
+                    try {
+                        appContext.assets.openFd(music.path).use { afd ->
+                            mp.setDataSource(afd.fileDescriptor, afd.startOffset, afd.length)
+                        }
+                        mp.isLooping = music.loop
+                        mp.prepare()
+                    } catch (e: Exception) {
+                        logger.e(e) { "Failed to load music: ${music.path}" }
+                    }
+                }
+            }
+        val volume = (music.volume * masterVolume).coerceIn(0f, 1f)
+        player.setVolume(volume, volume)
+        runCatching { player.start() }
+            .onFailure { logger.e(it) { "Failed to start music: ${music.path}" } }
+    }
+
+    override fun pauseMusic(music: Music) {
+        musicPlayers[music.path]?.let { if (it.isPlaying) it.pause() }
+    }
+
+    override fun stopMusic(music: Music) {
+        musicPlayers.remove(music.path)?.let { mp ->
+            runCatching { mp.stop() }
+            mp.release()
+        }
+    }
+
+    override fun setMasterVolume(volume: Float) {
+        masterVolume = volume.coerceIn(0f, 1f)
+        for (mp in musicPlayers.values) mp.setVolume(masterVolume, masterVolume)
+    }
+
+    override fun initialize(engine: Engine) {
+        logger.i { "AndroidAudioEngine initialized" }
+    }
+
+    override fun update(time: Time) {
+        // No per-frame work needed.
+    }
+
+    override fun shutdown() {
+        soundPool.release()
+        soundIds.clear()
+        activeStreams.clear()
+        for (mp in musicPlayers.values) {
+            runCatching { mp.stop() }
+            mp.release()
+        }
+        musicPlayers.clear()
+        logger.i { "AndroidAudioEngine shut down" }
+    }
+}


### PR DESCRIPTION
## What

Adds a real Android implementation of `prism-audio`'s `AudioEngine` interface, which until now only had `StubAudioEngine` (no-op).

`AndroidAudioEngine`:
- **SoundPool** (`USAGE_GAME`) for low-latency, polyphonic **sound effects**
- **MediaPlayer** for **music** (looping or one-shot)
- Loads from the app's `assets/` by relative path; tracks sample ids and active stream ids (so `stopSound` works); a per-path `MediaPlayer` map for play/pause/stop; master volume applied to both.

This adds the module's first `androidMain` source set. Sounds load asynchronously (SoundPool), so callers should preload before playing — documented on the class.

## Why

Motivated by a downstream Android tablet game that needs pop/hit/chime SFX. `StubAudioEngine` remains the default on every other platform, so existing demos are unaffected.

## Verification

- `:prism-audio:compileAndroidMain` is warning-clean (module sets `allWarningsAsErrors`).
- `./gradlew ktfmtCheck detektJvmMain jvmTest` — green.
- Will be exercised on-device via the downstream game (SoundPool playback of pop/hit/chime).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyeons-lab/codesmith/prism/pr/55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783458745&installation_id=134193259&pr_number=55&repository=hyeons-lab%2Fprism&return_to=https%3A%2F%2Fgithub.com%2Fhyeons-lab%2Fprism%2Fpull%2F55&signature=886a336f8e4e9989d93d336f901227ab27f16f9d68595951430f00a744d41c3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->