### PR TITLE
ci: add Maven Central publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,8 +82,15 @@ jobs:
         run: |
           echo "=== DRY RUN: publishToMavenLocal (no upload) ==="
           ./gradlew publishToMavenLocal --no-configuration-cache
-          echo "=== Artifacts written to ~/.m2/repository/com/hyeons-lab ==="
-          find ~/.m2/repository/com/hyeons-lab -name '*.pom' | sort
+          # Best-effort artifact listing — never fail the step on the report itself
+          # (the directory is absent if publishing wrote nothing, or if GROUP changes).
+          GROUP_DIR="$HOME/.m2/repository/com/hyeons-lab"
+          echo "=== Artifacts written to ${GROUP_DIR} ==="
+          if [ -d "$GROUP_DIR" ]; then
+            find "$GROUP_DIR" -name '*.pom' | sort
+          else
+            echo "::warning::No artifacts found under ${GROUP_DIR}"
+          fi
 
       # Real publish: upload to the Central Portal. SNAPSHOT versions route to the
       # snapshot repository; release versions create a manually-releasable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,101 @@
+name: Publish to Maven Central
+
+# Publishes the reusable Prism Kotlin Multiplatform libraries (prism-math,
+# prism-core, prism-renderer, prism-scene, prism-ecs, prism-input, prism-assets,
+# prism-audio, prism-native-widgets, prism-compose) to Maven Central via the
+# vanniktech maven-publish plugin. Coordinates/POM/signing come from
+# gradle.properties (GROUP, VERSION_NAME, POM_*) and each module's
+# `mavenPublishing { }` block.
+#
+# Runs on macOS so the Apple klib targets (iosArm64, iosSimulatorArm64,
+# macosArm64) are included in the publication — they are silently dropped on a
+# Linux runner. Tagging and the GitHub Release for the iOS XCFramework are owned
+# by release.yml; this workflow only publishes Maven artifacts.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (publish to ~/.m2 only, no upload)'
+        type: boolean
+        required: true
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish KMP libraries
+    runs-on: macos-26
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 25 (for toolchain)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      - name: Set up JDK 21 (default)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: always
+
+      - name: Get Kotlin version
+        id: kotlin-version
+        run: |
+          KOTLIN=$(grep '^kotlin ' gradle/libs.versions.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          if [ -z "$KOTLIN" ]; then
+            echo "::error::Failed to extract Kotlin version from libs.versions.toml"
+            exit 1
+          fi
+          echo "version=$KOTLIN" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan-${{ steps.kotlin-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-konan-
+
+      - name: Setup wgpu4k
+        uses: ./.github/actions/setup-wgpu4k
+        with:
+          rust-targets: aarch64-apple-ios,aarch64-apple-ios-sim
+
+      # Dry run: assemble every publication and write it into ~/.m2 without
+      # uploading. The Gradle analog of `cargo package`. Needs no secrets —
+      # vanniktech makes signing non-required for local publication and SNAPSHOTs.
+      - name: Publish to Maven Local (dry run)
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "=== DRY RUN: publishToMavenLocal (no upload) ==="
+          ./gradlew publishToMavenLocal --no-configuration-cache
+          echo "=== Artifacts written to ~/.m2/repository/com/hyeons-lab ==="
+          find ~/.m2/repository/com/hyeons-lab -name '*.pom' | sort
+
+      # Real publish: upload to the Central Portal. SNAPSHOT versions route to the
+      # snapshot repository; release versions create a manually-releasable
+      # deployment (no automatic release). Signing is required for releases —
+      # provide an ASCII-armored GPG key via the SIGNING_KEY* secrets.
+      - name: Publish to Maven Central
+        if: ${{ !inputs.dry_run }}
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        run: |
+          echo "=== PUBLISHING TO MAVEN CENTRAL ==="
+          ./gradlew publishToMavenCentral --no-configuration-cache

--- a/devlog/000026-ci-maven-publish-workflow.md
+++ b/devlog/000026-ci-maven-publish-workflow.md
@@ -1,0 +1,66 @@
+# 000026 — ci/maven-publish-workflow
+
+**Agent:** Claude (claude-opus-4-8) @ prism branch ci/maven-publish-workflow
+
+## Intent
+
+Add a CI workflow to publish Prism's reusable Kotlin Multiplatform libraries to
+Maven Central, "like the triage publish workflow". The triage workflow targets
+crates.io (Rust); Prism is KMP, so the analog is Maven Central via the
+`com.vanniktech.maven.publish` plugin. The user explicitly chose vanniktech.
+
+## What Changed
+
+- 2026-06-07T19:59-0700 `.github/workflows/publish.yml` — new
+  `workflow_dispatch` workflow with a `dry_run` boolean input (default true),
+  mirroring triage's dry-run/real shape. Runs on `macos-26` (to include Apple
+  klib targets), sets up JDK 25/21 + Gradle + konan cache + setup-wgpu4k (iOS
+  rust targets), then either `publishToMavenLocal` (dry run, no secrets) or
+  `publishToMavenCentral` (real, with `ORG_GRADLE_PROJECT_*` secrets).
+- 2026-06-07T19:59-0700 `devlog/plans/000026-01-maven-publish-workflow.md` —
+  design doc and audit of existing publishing config.
+
+## Decisions
+
+- 2026-06-07T19:59-0700 Workflow only — no per-module changes. Reasoning: 10
+  reusable libraries (math, core, renderer, scene, ecs, input, assets, audio,
+  native-widgets, compose) already carry a complete `mavenPublishing { }` block,
+  and `gradle.properties` already has GROUP/VERSION_NAME/POM_*. The plugin and
+  catalog entry exist. The only missing piece was CI.
+- 2026-06-07T19:59-0700 Excluded modules left as-is: demos (apps), prism-ios
+  (XCFramework via release.yml), prism-js (wasmJs executable / web SDK bundle),
+  prism-native (C-ABI shared libs), prism-flutter (integration bridge,
+  maintainer left unpublished). None are Maven-consumable Kotlin libraries.
+- 2026-06-07T19:59-0700 macOS runner, mirroring release.yml. Apple klib targets
+  are silently dropped from the publication on a Linux runner.
+- 2026-06-07T19:59-0700 Dry run → `publishToMavenLocal` (Gradle analog of
+  `cargo package`); real → `publishToMavenCentral`. No tagging/GH release here —
+  release.yml owns that for the XCFramework, so the two workflows don't contend
+  over tags.
+- 2026-06-07T19:59-0700 `--no-configuration-cache` on publish/sign tasks
+  (vanniktech publish + signing tasks are not config-cache compatible).
+
+## Issues
+
+- None encountered yet. Real publication requires repo secrets the user must add
+  (`MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `SIGNING_KEY`,
+  `SIGNING_KEY_PASSWORD`) — passed through as `ORG_GRADLE_PROJECT_*` env vars.
+
+## Research & Discoveries
+
+- vanniktech 0.36.0: `signAllPublications()` makes signing non-required for
+  SNAPSHOT versions and for `publishToMavenLocal`, so the dry-run path needs no
+  secrets. Signing is enforced only for non-SNAPSHOT remote publication.
+- Known limitation (pre-existing, not introduced here): renderer-and-up modules'
+  POMs depend on `io.ygdrasil:wgpu4k:0.2.0-SNAPSHOT`, a forked snapshot not on
+  Maven Central, so those artifacts aren't externally resolvable until wgpu4k is
+  published. prism-math / prism-core (no wgpu4k dep) are cleanly consumable.
+
+## Commits
+
+- HEAD — ci: add Maven Central publish workflow
+
+## Next Steps
+
+- User: add the four repo secrets, then run the workflow with `dry_run=true`
+  first to verify packaging, then `dry_run=false` to publish.

--- a/devlog/000026-ci-maven-publish-workflow.md
+++ b/devlog/000026-ci-maven-publish-workflow.md
@@ -56,9 +56,18 @@ crates.io (Rust); Prism is KMP, so the analog is Maven Central via the
   Maven Central, so those artifacts aren't externally resolvable until wgpu4k is
   published. prism-math / prism-core (no wgpu4k dep) are cleanly consumable.
 
+## Decisions
+
+- 2026-06-07T20:29-0700 (PR review) Made the dry-run artifact listing
+  best-effort: guard the `find` with `[ -d "$GROUP_DIR" ]` and emit a
+  `::warning::` instead of letting a missing directory fail the step. The listing
+  is only a report; the publish task itself is the source of truth for success.
+  Addresses Copilot review comment on publish.yml.
+
 ## Commits
 
-- HEAD — ci: add Maven Central publish workflow
+- f439ce7 — ci: add Maven Central publish workflow
+- HEAD — ci: make dry-run artifact listing non-fatal (PR review)
 
 ## Next Steps
 

--- a/devlog/plans/000026-01-maven-publish-workflow.md
+++ b/devlog/plans/000026-01-maven-publish-workflow.md
@@ -1,0 +1,84 @@
+# 000026-01 — Maven Central publish workflow
+
+## Thinking
+
+The user asked for a "publish to crates.io" workflow "like triage", then
+corrected: Prism is Kotlin Multiplatform, not Rust, so the analogous target is
+**Maven Central** via the vanniktech `com.vanniktech.maven.publish` plugin.
+
+Audit of the current state:
+
+- The vanniktech plugin (`com.vanniktech.maven.publish` 0.36.0) is already in
+  the version catalog and applied (`apply false`) at the root.
+- `gradle.properties` already carries the full publishing coordinates: `GROUP`
+  (`com.hyeons-lab`), `VERSION_NAME` (`0.1.0-SNAPSHOT`), POM URL/SCM/license/
+  developer metadata.
+- 10 reusable Kotlin libraries already declare a complete `mavenPublishing {
+  publishToMavenCentral(); signAllPublications(); pom { ... } }` block:
+  prism-math, prism-core, prism-renderer, prism-scene, prism-ecs, prism-input,
+  prism-assets, prism-audio, prism-native-widgets, prism-compose.
+- Correctly *not* configured (and should stay that way):
+  - demos (prism-android-demo, prism-demo-core, prism-flutter-demo) — apps,
+    not libraries.
+  - prism-ios — XCFramework aggregator, already released via `release.yml`.
+  - prism-js — produces a wasmJs *executable* / web SDK bundle, not a Maven lib.
+  - prism-native — produces native shared libs (.so/.dll/.dylib) for C-ABI FFI,
+    not a Gradle-consumable artifact.
+  - prism-flutter — integration bridge (XCFramework + Flutter plugin glue);
+    left unpublished by the maintainer, kept that way for now.
+
+So per-module configuration is already done and intentional. The only missing
+piece is the **CI workflow** — which is exactly the ask.
+
+Design choices, mirroring the triage `publish.yml` shape (workflow_dispatch +
+dry-run boolean) but adapted to Gradle/KMP:
+
+- **Runner = macOS (`macos-26`).** To include the Apple `klib` targets
+  (iosArm64, iosSimulatorArm64, macosArm64) in the publication, the publish
+  must run on macOS — Apple targets are silently dropped on Linux. Mirrors
+  `release.yml`.
+- **Dry-run path → `publishToMavenLocal`.** The Gradle analog of `cargo
+  package`: assembles + writes every publication into `~/.m2` without uploading.
+  Needs no secrets (vanniktech makes signing non-required for local + SNAPSHOT).
+- **Real path → `publishToMavenCentral`.** Uploads to the Central Portal.
+  For SNAPSHOT versions it routes to the snapshot repo; for release versions it
+  creates a manually-releasable deployment (no auto-release, conservative).
+- **No tag / GitHub Release here.** `release.yml` already owns tagging and the
+  GH release for the XCFramework. Keeping the Maven workflow publish-only avoids
+  two workflows fighting over tags.
+- **`--no-configuration-cache`** on the publish/sign tasks — vanniktech's
+  publish + signing tasks are not configuration-cache compatible.
+- Reuse the existing env scaffolding: JDK 25 (toolchain) + JDK 21 (default),
+  `gradle/actions/setup-gradle`, konan cache, and `./.github/actions/setup-wgpu4k`
+  with the iOS rust targets (renderer-and-up modules need wgpu4k in mavenLocal
+  to compile).
+
+Secrets (added to repo settings by the user, standard vanniktech names passed
+as `ORG_GRADLE_PROJECT_*`):
+
+- `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` — Central Portal user token.
+- `SIGNING_KEY` (ASCII-armored GPG secret key) / `SIGNING_KEY_PASSWORD` —
+  required only for non-SNAPSHOT releases.
+
+Known limitation to surface (not introduced by this workflow): renderer-and-up
+modules' POMs depend on `io.ygdrasil:wgpu4k:0.2.0-SNAPSHOT`, a forked snapshot
+not on Maven Central, so those artifacts aren't externally resolvable yet. The
+no-wgpu4k libraries (prism-math, prism-core) are cleanly consumable.
+
+## Plan
+
+1. Add `.github/workflows/publish.yml`:
+   - `name: Publish to Maven Central`
+   - `on: workflow_dispatch` with a required `dry_run` boolean input (default
+     `true`).
+   - `permissions: contents: read`.
+   - Single `publish` job on `macos-26`:
+     - checkout, JDK 25 + 21, setup-gradle, konan cache, setup-wgpu4k (iOS
+       rust targets).
+     - dry-run → `./gradlew publishToMavenLocal --no-configuration-cache`.
+     - real → `./gradlew publishToMavenCentral --no-configuration-cache` with
+       the four `ORG_GRADLE_PROJECT_*` secrets in `env`.
+2. Devlog 000026.
+3. ktfmt is irrelevant (YAML only); validate YAML parses. Optionally smoke-test
+   `publishToMavenLocal` for prism-math locally (no secrets needed).
+4. Draft PR, then mark ready.


### PR DESCRIPTION
Add `.github/workflows/publish.yml` — a `workflow_dispatch` workflow that publishes the reusable Prism KMP libraries to Maven Central via the vanniktech maven-publish plugin (the Kotlin analog of triage's crates.io publish workflow).

## What it does
- `dry_run` input (default `true`) → `publishToMavenLocal` (assembles every publication into `~/.m2`, no upload, no secrets needed).
- `dry_run=false` → `publishToMavenCentral` with `ORG_GRADLE_PROJECT_*` secrets.
- Runs on `macos-26` so the Apple klib targets (iosArm64, iosSimulatorArm64, macosArm64) are included in the publication — they are silently dropped on a Linux runner.
- Reuses the JDK 25/21 + Gradle + konan cache + `setup-wgpu4k` scaffolding from `release.yml`.
- Tagging and the GitHub Release for the iOS XCFramework stay owned by `release.yml`; this workflow is publish-only.

## Why workflow-only
The 10 reusable libraries (math, core, renderer, scene, ecs, input, assets, audio, native-widgets, compose) already declare a complete `mavenPublishing { }` block, and `gradle.properties` already carries GROUP / VERSION_NAME / POM_*. The plugin and catalog entry exist. The only missing piece was the CI entry point. Demos, prism-ios (XCFramework), prism-js (web bundle), prism-native (C-ABI libs), and prism-flutter (bridge) are intentionally not published.

## Required before first real run
Repo secrets are **not** yet configured — add:
- `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` (Central Portal user token)
- `SIGNING_KEY` (ASCII-armored GPG secret key) / `SIGNING_KEY_PASSWORD` (required for non-SNAPSHOT releases)

## Known limitation (pre-existing)
renderer-and-up POMs depend on `io.ygdrasil:wgpu4k:0.2.0-SNAPSHOT`, a forked snapshot not on Maven Central, so those artifacts aren't externally resolvable until wgpu4k is published. prism-math / prism-core (no wgpu4k dep) are cleanly consumable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyeons-lab/codesmith/prism/pr/56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783479698&installation_id=134193259&pr_number=56&repository=hyeons-lab%2Fprism&return_to=https%3A%2F%2Fgithub.com%2Fhyeons-lab%2Fprism%2Fpull%2F56&signature=16bb1d360574b6c0a901575cc50dfd9d06d2da3db9870159fe44fd006e5be6fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->