### PR TITLE
chore: bump artifact version to 0.1.0 and fix Flutter plugin coordinates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This file provides guidance to ai agents when working with code in this reposito
 Prism is a modular, cross-platform 3D game engine built with Kotlin Multiplatform (KMP). It targets JVM Desktop, Web (WASM), iOS, Android, and macOS/Linux/Windows native platforms with a single Kotlin codebase. The rendering backend uses **wgpu4k** for cross-platform GPU access (Vulkan, Metal, DX12, WebGPU).
 
 - **Group ID**: com.hyeons-lab
-- **Version**: 0.1.0-SNAPSHOT
+- **Version**: 0.1.0
 - **Docs**: PLAN.md (tech spec), BUILD_STATUS.md (milestone status)
 
 ## Build Commands

--- a/devlog/000028-chore-bump-version-0.1.0.md
+++ b/devlog/000028-chore-bump-version-0.1.0.md
@@ -1,0 +1,65 @@
+# 000028 — chore/bump-version-0.1.0
+
+**Agent:** Claude (claude-opus-4-8) @ prism branch chore/bump-version-0.1.0
+
+## Intent
+
+Bump the published artifact version `0.1.0-SNAPSHOT` → `0.1.0`, then fix the
+Maven coordinate mismatches in the Flutter plugin's Android build that the bump
+exposed.
+
+## What Changed
+
+- 2026-06-07T21:13-0700 `gradle.properties` — `VERSION_NAME` `0.1.0-SNAPSHOT` →
+  `0.1.0` (canonical version for all com.hyeons-lab publications).
+- 2026-06-07T21:13-0700 `AGENTS.md` — Version doc line → `0.1.0`.
+- 2026-06-07T21:13-0700 `prism-flutter/flutter_plugin/android/build.gradle` — the
+  two prism deps changed from `engine.prism:…:0.1.0-SNAPSHOT` to
+  `com.hyeons-lab:prism-flutter-android:0.1.0` and
+  `com.hyeons-lab:prism-native-widgets-android:0.1.0`; removed the now-dead
+  `includeGroupByRegex("engine\\.prism.*")` mavenLocal content filter.
+- 2026-06-07T21:13-0700 `prism-flutter/build.gradle.kts` — apply
+  `libs.plugins.maven.publish` and add a `mavenPublishing { }` block (mirrors
+  prism-native-widgets) so `com.hyeons-lab:prism-flutter-android` is actually
+  published; the flutter plugin depended on an artifact that was published
+  nowhere.
+
+## Decisions
+
+- 2026-06-07T21:13-0700 `engine.prism` is a dead group — nothing publishes under
+  it (only stale package paths in PLAN.md). Real group is `com.hyeons-lab`, real
+  packages are `com.hyeonslab.prism.*`. So the flutter plugin deps were simply
+  wrong; corrected to the real coordinates rather than making the build resolve
+  a nonexistent group.
+- 2026-06-07T21:13-0700 Publish `prism-flutter` rather than drop the dep. The
+  flutter plugin's Android library genuinely needs the prism-flutter Android AAR;
+  it `api`-exposes prism-core + prism-native-widgets (both already published), so
+  publishing it is the consistent fix and yields a clean POM.
+- 2026-06-07T21:13-0700 Left the historical devlog (000013) reference to the old
+  coordinate untouched — devlogs are append-only records of what was true then.
+- 2026-06-07T21:44-07:00 (PR review) Reference `${project.version}` in the two
+  prism dep coordinates instead of repeating the `0.1.0` literal. The plugin is
+  versioned in lockstep with the SDK (its own `version = "0.1.0"` is the single
+  source), so this removes the duplication that caused the original drift.
+
+## Issues
+
+- None. `:prism-flutter:publishAndroidPublicationToMavenLocal` produced
+  `com.hyeons-lab:prism-flutter-android:0.1.0` whose POM depends on
+  `com.hyeons-lab:prism-core-android:0.1.0` and `…:prism-native-widgets-android:0.1.0`
+  — matching the flutter plugin deps. `ktfmtCheck detektJvmMain jvmTest` and
+  `:prism-flutter:compileAndroidMain` pass.
+
+## Research & Discoveries
+
+- vanniktech reports `group: prism / version: unspecified` for the Gradle project
+  even when publishing correctly — it sets publication groupId/version from
+  `GROUP`/`VERSION_NAME` in gradle.properties, not from `project.group/version`.
+  prism-native-widgets (known-good) shows the same, so this is expected.
+- 0.1.0 is a release version: a real `publishToMavenCentral` now requires GPG
+  signing (the publish workflow already wires `SIGNING_KEY*`); the
+  `publishToMavenLocal` dry-run path does not require it.
+
+## Commits
+
+- HEAD — chore: bump artifact version to 0.1.0 and fix Flutter plugin coordinates

--- a/devlog/plans/000028-01-bump-version-0.1.0.md
+++ b/devlog/plans/000028-01-bump-version-0.1.0.md
@@ -1,0 +1,53 @@
+# 000028-01 — Bump artifact version to 0.1.0 + fix coordinate mismatches
+
+## Thinking
+
+User asked to bump the published artifact version from `0.1.0-SNAPSHOT` to
+`0.1.0`, then to fix the Maven coordinate mismatches surfaced while doing it.
+
+The canonical version lives in `gradle.properties` (`VERSION_NAME`), read by the
+vanniktech maven-publish plugin. `GROUP=com.hyeons-lab`.
+
+Coordinate audit of `prism-flutter/flutter_plugin/android/build.gradle` (a plain
+AGP library that consumes the prism KMP android artifacts from mavenLocal):
+
+- Its two prism deps used group `engine.prism` — but every prism module
+  publishes under `com.hyeons-lab`. Wrong group → never resolves.
+- They pinned `0.1.0-SNAPSHOT` — stale once the version bumps to `0.1.0`.
+- `prism-flutter-android` was referenced but `prism-flutter` had **no**
+  `mavenPublishing` block, so that artifact is published nowhere (confirmed: no
+  publish step anywhere references it). So even after fixing the group the dep
+  could not resolve.
+
+`engine.prism` is a dead group: nothing publishes under it; the only other hits
+are stale package paths in PLAN.md (the real packages are `com.hyeonslab.prism.*`).
+
+Fix is therefore three-fold and internally consistent:
+1. `VERSION_NAME` → `0.1.0` (+ the AGENTS.md doc line).
+2. Flutter plugin deps → `com.hyeons-lab:…:0.1.0`; drop the now-dead
+   `includeGroupByRegex("engine\\.prism.*")` mavenLocal filter.
+3. Publish `prism-flutter` (add `mavenPublishing { }` mirroring
+   `prism-native-widgets`) so `com.hyeons-lab:prism-flutter-android:0.1.0`
+   actually exists. It `api`-depends on the already-published prism-core and
+   prism-native-widgets, so its POM is consistent.
+
+Verified by publishing the android variant to mavenLocal: produced
+`com.hyeons-lab:prism-flutter-android:0.1.0` whose POM depends on
+`com.hyeons-lab:prism-core-android:0.1.0` and `…:prism-native-widgets-android:0.1.0`
+— matching the flutter plugin deps exactly.
+
+Note: 0.1.0 is a release version, so a real `publishToMavenCentral` now requires
+GPG signing (the publish workflow already passes `SIGNING_KEY*`); `publishToMavenLocal`
+(the dry-run path) does not.
+
+## Plan
+
+1. `gradle.properties`: `VERSION_NAME=0.1.0`.
+2. `AGENTS.md`: Version line → 0.1.0.
+3. `prism-flutter/flutter_plugin/android/build.gradle`: deps →
+   `com.hyeons-lab:…:0.1.0`; remove `engine.prism` repo filter.
+4. `prism-flutter/build.gradle.kts`: apply `maven.publish` plugin + add
+   `mavenPublishing { publishToMavenCentral(); signAllPublications(); pom { } }`.
+5. Validate: ktfmtCheck/detekt/jvmTest, `:prism-flutter:compileAndroidMain`,
+   and a mavenLocal publish of the android variant to confirm the coordinate.
+6. Devlog 000028, commit, PR.

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ android.nonTransitiveRClass=true
 
 # Publishing
 GROUP=com.hyeons-lab
-VERSION_NAME=0.1.0-SNAPSHOT
+VERSION_NAME=0.1.0
 POM_URL=https://github.com/hyeons-lab/prism
 POM_SCM_URL=https://github.com/hyeons-lab/prism
 POM_SCM_CONNECTION=scm:git:git://github.com/hyeons-lab/prism.git

--- a/prism-flutter/build.gradle.kts
+++ b/prism-flutter/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   alias(libs.plugins.kotlin.multiplatform)
   alias(libs.plugins.android.kotlin.multiplatform.library)
   alias(libs.plugins.skie)
+  alias(libs.plugins.maven.publish)
 }
 
 kotlin {
@@ -250,4 +251,12 @@ tasks.register<Copy>("bundleNativeWindows") {
   dependsOn(":prism-native:linkReleaseSharedMingwX64")
   from(prismNativeBuildDir.file("bin/mingwX64/releaseShared/prism.dll"))
   into(layout.projectDirectory.dir("flutter_plugin/windows/native"))
+}
+
+mavenPublishing {
+  publishToMavenCentral()
+  signAllPublications()
+  pom {
+    description.set("Flutter bridge for the Prism engine (MethodChannel + platform views, WASM)")
+  }
 }

--- a/prism-flutter/flutter_plugin/android/build.gradle
+++ b/prism-flutter/flutter_plugin/android/build.gradle
@@ -38,7 +38,6 @@ repositories {
         content {
             includeGroup("io.ygdrasil")
             includeGroup("com.hyeons-lab")
-            includeGroupByRegex("engine\\.prism.*")
         }
     }
     google()
@@ -48,8 +47,10 @@ repositories {
 dependencies {
     // Prism KMP SDK modules only — no demo deps.
     // The host app provides DemoAndroidBridge + FlutterMethodHandler via PrismFlutterPlugin.configure().
-    implementation("engine.prism:prism-flutter-android:0.1.0-SNAPSHOT")
-    implementation("engine.prism:prism-native-widgets-android:0.1.0-SNAPSHOT")
+    // Versioned in lockstep with this plugin (see `version` above) — reference
+    // project.version so the prism SDK coordinates can't drift out of sync.
+    implementation("com.hyeons-lab:prism-flutter-android:${project.version}")
+    implementation("com.hyeons-lab:prism-native-widgets-android:${project.version}")
 
     implementation("io.ygdrasil:wgpu4k-android:0.2.0-SNAPSHOT")
     implementation("io.ygdrasil:wgpu4k-toolkit-android:0.2.0-SNAPSHOT")


### PR DESCRIPTION
Bumps the published artifact version and fixes the Maven coordinate mismatches the bump exposed.

## Version bump
- `gradle.properties`: `VERSION_NAME` `0.1.0-SNAPSHOT` → `0.1.0` (the canonical version for all `com.hyeons-lab` publications).
- `AGENTS.md`: Version doc line → `0.1.0`.

## Coordinate fixes (`prism-flutter/flutter_plugin/android/build.gradle`)
The Flutter plugin's Android library consumed the prism KMP android artifacts under the wrong coordinates:
- **Group:** used `engine.prism:` but every prism module publishes under `com.hyeons-lab:`. `engine.prism` is a dead group — nothing publishes under it. → corrected to `com.hyeons-lab:…:0.1.0`, and dropped the now-obsolete `includeGroupByRegex("engine\\.prism.*")` mavenLocal filter.
- **Unpublished artifact:** it depended on `prism-flutter-android`, but `prism-flutter` had no `mavenPublishing` block, so that artifact was published nowhere. → added publishing to `prism-flutter` (mirrors `prism-native-widgets`). It `api`-depends on the already-published `prism-core` + `prism-native-widgets`, so its POM is consistent.

## Verification
- `:prism-flutter:publishAndroidPublicationToMavenLocal` produces `com.hyeons-lab:prism-flutter-android:0.1.0` whose POM depends on `com.hyeons-lab:prism-core-android:0.1.0` and `…:prism-native-widgets-android:0.1.0` — matching the plugin deps exactly.
- `ktfmtCheck detektJvmMain jvmTest` and `:prism-flutter:compileAndroidMain` pass.

## Note
`prism-flutter` is now in the published set, so the Maven publish workflow (#56) will publish it too. `0.1.0` is a release version, so a real `publishToMavenCentral` now requires GPG signing (the workflow already wires `SIGNING_KEY*`); the `publishToMavenLocal` dry run does not.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyeons-lab/codesmith/prism/pr/58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783484351&installation_id=134193259&pr_number=58&repository=hyeons-lab%2Fprism&return_to=https%3A%2F%2Fgithub.com%2Fhyeons-lab%2Fprism%2Fpull%2F58&signature=48b3df63190828bf4549813da7592561e153f7d77d6d40491313f2ddbc035ee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->