### PR TITLE
ci: attribute and SSH-sign the release commit and tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,15 +124,37 @@ jobs:
       - name: Commit, tag, and push
         env:
           VERSION: ${{ inputs.version }}
+          GIT_SSH_SIGNING_KEY: ${{ secrets.GIT_SSH_SIGNING_KEY }}
+          RELEASE_GIT_EMAIL: ${{ secrets.RELEASE_GIT_EMAIL }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # The commit author email comes from the RELEASE_GIT_EMAIL secret. It
+          # must match the email verified on the maintainer's GitHub account and
+          # tied to the SSH *Signing Key* for the commit/tag to show "Verified".
+          if [ -z "$RELEASE_GIT_EMAIL" ]; then
+            echo "::error::RELEASE_GIT_EMAIL secret is not set"
+            exit 1
+          fi
+
+          # SSH-sign the release commit + tag so GitHub marks them "Verified".
+          # Requires: the matching public key added to the GitHub account as a
+          # *Signing Key*. The key must have no passphrase (dedicated CI key).
+          SIGNING_KEY="${RUNNER_TEMP}/git_ssh_signing_key"
+          install -m 600 /dev/null "$SIGNING_KEY"
+          printf '%s\n' "$GIT_SSH_SIGNING_KEY" > "$SIGNING_KEY"
+          ssh-keygen -y -f "$SIGNING_KEY" > "${SIGNING_KEY}.pub"
+
+          git config user.name "David Berrios"
+          git config user.email "$RELEASE_GIT_EMAIL"
+          git config gpg.format ssh
+          git config user.signingkey "${SIGNING_KEY}.pub"
+          git config commit.gpgsign true
+          git config tag.gpgsign true
 
           git add Package.swift
           git diff --cached --quiet && echo "No changes to Package.swift" && exit 1
 
-          git commit -m "chore: update Package.swift for v${VERSION}"
-          git tag "v${VERSION}"
+          git commit -S -m "chore: update Package.swift for v${VERSION}"
+          git tag -s "v${VERSION}" -m "v${VERSION}"
           git push origin main "v${VERSION}"
 
       - name: Create GitHub Release

--- a/devlog/000029-ci-release-commit-author.md
+++ b/devlog/000029-ci-release-commit-author.md
@@ -1,0 +1,62 @@
+# 000029 — ci/release-commit-author
+
+**Agent:** Claude (claude-opus-4-8) @ prism branch ci/release-commit-author
+
+## Intent
+
+Attribute the release workflow's automated commit (the Package.swift update +
+tag) to the maintainer instead of the generic `github-actions[bot]`, and
+SSH-sign the commit + tag so GitHub marks them "Verified". Workflows stay
+separate — no consolidation of release.yml and publish.yml.
+
+## What Changed
+
+- 2026-06-07T21:29-07:00 `.github/workflows/release.yml` — in the "Commit, tag,
+  and push" step, set the git author to `David Berrios` /
+  `<maintainer-email>` instead of `github-actions[bot]` /
+  `github-actions[bot]@users.noreply.github.com`.
+- 2026-06-07T21:34-07:00 `.github/workflows/release.yml` — SSH-sign the release
+  commit and tag (`gpg.format=ssh`, `commit.gpgsign`/`tag.gpgsign`, `commit -S`,
+  `tag -s`) using a `GIT_SSH_SIGNING_KEY` secret, so GitHub marks them "Verified".
+- 2026-06-07T21:47-07:00 `.github/workflows/release.yml` — source the commit
+  author email from a `RELEASE_GIT_EMAIL` secret (guarded — the step fails if it
+  is unset) instead of hardcoding it; the name stays `David Berrios`.
+
+## Decisions
+
+- 2026-06-07T21:29-07:00 Keep `release.yml` and `publish.yml` separate; only the
+  commit authorship changes. (An earlier exploration toward merging Maven publish
+  into release.yml was discarded at the user's direction — "keep them separate".)
+- 2026-06-07T21:29-07:00 Scope limited to the release commit identity. POM
+  developer info and repo/SCM URLs in gradle.properties were intentionally left
+  unchanged.
+- 2026-06-07T21:34-07:00 SSH signing over GPG. Reasoning: no gpg-agent /
+  loopback-pinentry / passphrase wrangling in CI, no third-party action (prism
+  uses only `actions/*` + `gradle/actions`), and the dedicated CI key is
+  unrelated to the Maven `SIGNING_KEY` (whose UID is the Central identity, not
+  `<maintainer-email>`). Verified the exact step logic locally: signed commit
+  and tag both report a good signature (`%G?` = `G`).
+
+## Issues
+
+- None. YAML validates; local smoke test of the step (ssh-keygen derive pub +
+  git config ssh signing + `commit -S` + `tag -s`) yields `git verify-commit`
+  and `git verify-tag` "Good signature".
+- 2026-06-07T21:45-07:00 (PR review) Redacted the maintainer email to
+  `<maintainer-email>` (CONVENTIONS.md forbids PII in devlogs; the real value
+  lives in release.yml) and fixed timestamp offsets to the `-07:00` colon form.
+
+## Required setup (one-time, by maintainer)
+
+- Generate a no-passphrase signing key:
+  `ssh-keygen -t ed25519 -C "prism release signing" -f prism_release_signing -N ""`
+- Add `prism_release_signing.pub` to GitHub → Settings → SSH and GPG keys →
+  New SSH key → **Key type: Signing Key**.
+- Add the private key `prism_release_signing` as repo secret
+  `GIT_SSH_SIGNING_KEY`.
+- Ensure the maintainer email is a verified email on the GitHub account, and set
+  it as the `RELEASE_GIT_EMAIL` secret (used as the commit author email).
+
+## Commits
+
+- HEAD — ci: attribute and SSH-sign the release commit and tag


### PR DESCRIPTION
Attributes the Release workflow's automated commit to the maintainer **and** SSH-signs the commit + tag so GitHub marks them **Verified**.

In `release.yml`'s "Commit, tag, and push" step:
- git author name set to the maintainer (was `github-actions[bot]`); the author **email is read from the `RELEASE_GIT_EMAIL` secret** (guarded — the step fails if it is unset) rather than hardcoded.
- SSH-sign the commit and the `v<version>` tag: `gpg.format=ssh`, `commit.gpgsign`/`tag.gpgsign`, `git commit -S`, `git tag -s`, using a `GIT_SSH_SIGNING_KEY` secret. The tag becomes a signed annotated tag (was lightweight).

### Why SSH signing (not GPG)
No gpg-agent / loopback-pinentry / passphrase wrangling in CI, and no third-party action (this repo uses only `actions/*` + `gradle/actions`). The dedicated CI key is unrelated to the Maven `SIGNING_KEY` (whose identity is the Central publisher).

### Verified locally
Ran the exact step logic against an ephemeral ed25519 key: signed commit and tag both report a good signature (`git log %G?` = `G`; `git verify-commit`/`git verify-tag` = "Good signature").

### One-time setup required before the next release
1. `ssh-keygen -t ed25519 -C "prism release signing" -f prism_release_signing -N ""` (no passphrase).
2. Add `prism_release_signing.pub` to GitHub → Settings → SSH and GPG keys → New SSH key → **Key type: Signing Key**.
3. Add the private key `prism_release_signing` as repo secret `GIT_SSH_SIGNING_KEY`.
4. Set repo secret `RELEASE_GIT_EMAIL` to the maintainer's verified email, and ensure that email is verified on the account.

`release.yml` and `publish.yml` stay **separate** — no workflow consolidation.