### PR TITLE
ci: default release version from gradle.properties, allow override

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. 0.1.0, 0.1.0-rc.1)"
-        required: true
+        description: "Override version (leave blank to use VERSION_NAME from gradle.properties)"
+        required: false
+        default: ""
         type: string
 
 permissions:
@@ -24,9 +25,22 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Validate version input
+      - name: Resolve version
+        id: version
         run: |
+          # Default to the published artifact version (VERSION_NAME in
+          # gradle.properties); the workflow_dispatch input overrides it.
           VERSION="${{ inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            VERSION=$(grep -E '^VERSION_NAME=' gradle.properties | head -1 | cut -d'=' -f2- | tr -d '[:space:]')
+            echo "No version override; using artifact version from gradle.properties: ${VERSION}"
+          else
+            echo "Using version override from input: ${VERSION}"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not determine version (no input and no VERSION_NAME in gradle.properties)"
+            exit 1
+          fi
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
             echo "::error::Invalid version format: ${VERSION}"
             echo "Expected: semver (e.g. 0.1.0, 0.1.0-rc.1)"
@@ -36,6 +50,7 @@ jobs:
             echo "::error::Tag v${VERSION} already exists"
             exit 1
           fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Version: ${VERSION}"
 
       - name: Set up JDK 25 (for toolchain)
@@ -110,7 +125,7 @@ jobs:
 
       - name: Update Package.swift
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
           CHECKSUM: ${{ steps.package.outputs.checksum }}
         run: |
           DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/v${VERSION}/Prism.xcframework.zip"
@@ -123,7 +138,7 @@ jobs:
 
       - name: Commit, tag, and push
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
           GIT_SSH_SIGNING_KEY: ${{ secrets.GIT_SSH_SIGNING_KEY }}
           RELEASE_GIT_EMAIL: ${{ secrets.RELEASE_GIT_EMAIL }}
         run: |
@@ -160,7 +175,7 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
           ZIP_PATH: ${{ steps.package.outputs.zip_path }}
         run: |
           gh release create "v${VERSION}" "$ZIP_PATH" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,11 @@ jobs:
           # gradle.properties); the workflow_dispatch input overrides it.
           VERSION="${{ inputs.version }}"
           if [ -z "$VERSION" ]; then
-            VERSION=$(grep -E '^VERSION_NAME=' gradle.properties | head -1 | cut -d'=' -f2- | tr -d '[:space:]')
+            # awk (single process, exits 0 even with no match) so the explicit
+            # empty-VERSION check below handles a missing key — a grep pipeline
+            # would trip the shell's -e/pipefail before we get there. Tolerates
+            # optional whitespace around '='.
+            VERSION=$(awk '/^[[:space:]]*VERSION_NAME[[:space:]]*=/ { sub(/^[^=]*=[[:space:]]*/, "", $0); gsub(/[[:space:]]/, "", $0); print; exit }' gradle.properties)
             echo "No version override; using artifact version from gradle.properties: ${VERSION}"
           else
             echo "Using version override from input: ${VERSION}"
@@ -41,12 +45,14 @@ jobs:
             echo "::error::Could not determine version (no input and no VERSION_NAME in gradle.properties)"
             exit 1
           fi
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Invalid version format: ${VERSION}"
-            echo "Expected: semver (e.g. 0.1.0, 0.1.0-rc.1)"
+            echo "Expected: semver (e.g. 0.1.0, 0.1.0-rc.1, 1.2.3+build.5)"
             exit 1
           fi
-          if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+          # Check the tag ref specifically, not any resolvable revision (a branch
+          # named vX.Y.Z would otherwise falsely report the tag as existing).
+          if git show-ref --verify --quiet "refs/tags/v${VERSION}"; then
             echo "::error::Tag v${VERSION} already exists"
             exit 1
           fi

--- a/devlog/000030-ci-release-auto-version.md
+++ b/devlog/000030-ci-release-auto-version.md
@@ -31,6 +31,16 @@ optional override.
 - 2026-06-07T22:11-07:00 Expose the resolved version as a step output and thread
   it through downstream steps, rather than re-reading the file in each step —
   one resolution + validation point.
+- 2026-06-07T22:25-07:00 (PR review) Three hardening fixes to the Resolve step:
+  (1) extract `VERSION_NAME` with `awk` instead of a `grep | head | cut | tr`
+  pipeline — Actions runs bash with `-e -o pipefail`, so a missing key would trip
+  the pipeline before the explicit empty-VERSION error; `awk` is one process that
+  exits 0 with no match and tolerates whitespace around `=`. (2) Check tag
+  uniqueness with `git show-ref --verify --quiet refs/tags/v$VERSION` instead of
+  `git rev-parse v$VERSION`, which resolves any ref (a branch named `vX.Y.Z` would
+  false-positive). (3) Broaden the semver regex to accept hyphenated prerelease
+  (`1.2.3-alpha-1`) and build metadata (`1.2.3+build.5`), matching the "semver"
+  error wording.
 
 ## Issues
 
@@ -41,4 +51,5 @@ optional override.
 
 ## Commits
 
-- HEAD — ci: default release version from gradle.properties, allow override
+- 852baf6 — ci: default release version from gradle.properties, allow override
+- HEAD — ci: harden version resolution (awk, tag-ref check, semver regex) (PR review)

--- a/devlog/000030-ci-release-auto-version.md
+++ b/devlog/000030-ci-release-auto-version.md
@@ -1,0 +1,44 @@
+# 000030 — ci/release-auto-version
+
+**Agent:** Claude (claude-opus-4-8) @ prism branch ci/release-auto-version
+
+## Intent
+
+Stop requiring the maintainer to type a version when triggering the Release
+workflow. Default to the project's published artifact version and allow an
+optional override.
+
+## What Changed
+
+- 2026-06-07T22:11-07:00 `.github/workflows/release.yml` — make the `version`
+  workflow_dispatch input optional (`required: false`, `default: ""`). Renamed
+  "Validate version input" → "Resolve version" (`id: version`): when the input
+  is blank it reads `VERSION_NAME` from `gradle.properties`; a non-blank input
+  overrides it. The step validates semver + tag-uniqueness and exposes the
+  resolved value as `steps.version.outputs.version`. Downstream steps (Update
+  Package.swift, Commit/tag/push, Create GitHub Release) now reference that
+  output instead of `inputs.version`.
+
+## Decisions
+
+- 2026-06-07T22:11-07:00 Read the version from `gradle.properties` (`VERSION_NAME`),
+  not the toml. The user first said "the toml file", but the artifact version is
+  not there — `gradle/libs.versions.toml` only holds tool/dependency versions
+  (kotlin, agp, wgpu4k, …). `VERSION_NAME` in `gradle.properties` is the single
+  source vanniktech publishes from, so reading it there keeps one source of
+  truth; adding the version to the toml would create a second that can drift.
+  Confirmed with the user.
+- 2026-06-07T22:11-07:00 Expose the resolved version as a step output and thread
+  it through downstream steps, rather than re-reading the file in each step —
+  one resolution + validation point.
+
+## Issues
+
+- None. YAML validates. Smoke-tested the resolution shell logic against the real
+  `gradle.properties` (now `VERSION_NAME=0.1.0` after #58): empty input resolves
+  to `0.1.0`; an override (`0.2.0-rc.1`) is used verbatim; both pass the semver
+  check.
+
+## Commits
+
+- HEAD — ci: default release version from gradle.properties, allow override


### PR DESCRIPTION
Makes the Release workflow's `version` input optional so a maintainer can trigger a release without typing a version — it defaults to the project's artifact version and can still be overridden.

## What changed
- The `version` workflow_dispatch input is now `required: false` (default `""`).
- Renamed "Validate version input" → **"Resolve version"** (`id: version`):
  - blank input → reads `VERSION_NAME` from `gradle.properties` (the published artifact version),
  - non-blank input → used as an override,
  - then validates semver + tag-uniqueness and exposes the result as `steps.version.outputs.version`.
- Downstream steps (Update Package.swift, Commit/tag/push, Create GitHub Release) reference that output instead of `inputs.version`.

## Why gradle.properties (not the TOML)
The artifact version isn't in `gradle/libs.versions.toml` — that only holds tool/dependency versions (kotlin, agp, wgpu4k, …). `VERSION_NAME` in `gradle.properties` is the single source the vanniktech plugin publishes from, so reading it there keeps one source of truth. Adding the version to the TOML would create a second one that can drift.

## Verification
- YAML validates.
- Smoke-tested the resolution logic against the real `gradle.properties` (`VERSION_NAME=0.1.0`): blank input resolves to `0.1.0`; an override like `0.2.0-rc.1` is used verbatim; both pass the semver check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyeons-lab/codesmith/prism/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783487507&installation_id=134193259&pr_number=60&repository=hyeons-lab%2Fprism&return_to=https%3A%2F%2Fgithub.com%2Fhyeons-lab%2Fprism%2Fpull%2F60&signature=41cea77eac803260de3151007e6445e8175cf4ba13476002f1e548c23b754bcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->