### PR TITLE
fix(compose): drop unsupported linux/mingw native targets

### DIFF
--- a/devlog/000031-fix-compose-linux-publish.md
+++ b/devlog/000031-fix-compose-linux-publish.md
@@ -1,0 +1,44 @@
+# 000031 — fix/compose-linux-publish
+
+**Agent:** Claude (claude-opus-4-8) @ prism branch fix/compose-linux-publish
+
+## Intent
+
+Fix the failing `publishToMavenCentral` run
+(actions/runs/27117220819) — the first real Maven Central publish.
+
+## What Changed
+
+- 2026-06-07T22:20-07:00 `prism-compose/build.gradle.kts` — removed the
+  `linuxX64()` and `mingwX64()` targets (replaced with an explanatory comment).
+  Compose Multiplatform has no linux/windows Kotlin/Native target, so this module
+  had no source for them.
+
+## Decisions
+
+- 2026-06-07T22:20-07:00 Remove the targets rather than add stub source. Compose
+  Multiplatform does not publish artifacts for `linuxX64`/`mingwX64`; Linux and
+  Windows are covered by the JVM Desktop target (which `prism-compose` already
+  has via `jvm()`). The native targets were non-functional and only existed to
+  break publishing.
+
+## Issues
+
+- **Root cause:** `prism-compose` is the only published module with **no
+  `commonMain` sources** (its code lives in `nonNativeMain` = jvm/android/wasm and
+  `appleMain` = ios/macos). The declared `linuxX64()`/`mingwX64()` targets
+  therefore compiled nothing (`compileKotlinLinuxX64` = NO-SOURCE → no klib), but
+  the publication still ran `generateMetadataFileForLinuxX64Publication`, which
+  failed with `FileNotFoundException: prism-compose-linuxX64Main.klib`. This was
+  latent until the first full multiplatform `publishToMavenCentral`.
+- Audited all 11 published modules: only `prism-compose` has native targets
+  without `commonMain` source; every other module (incl. the newly-published
+  `prism-flutter`) has `commonMain` sources, so their klibs build and publish.
+- Verified: `:prism-compose:publishToMavenLocal` now BUILD SUCCESSFUL (generates
+  Android/IosArm64/IosSimulatorArm64/Jvm/Macos/WasmJs/root publications, no
+  Linux/Mingw); `publish(LinuxX64|MingwX64)Publication` tasks no longer exist;
+  `:prism-compose:ktfmtCheck` passes.
+
+## Commits
+
+- HEAD — fix(compose): drop unsupported linux/mingw native targets

--- a/prism-compose/build.gradle.kts
+++ b/prism-compose/build.gradle.kts
@@ -19,8 +19,10 @@ kotlin {
   iosArm64()
   iosSimulatorArm64()
   if (isMac) macosArm64()
-  linuxX64()
-  mingwX64()
+  // No linuxX64()/mingwX64(): Compose Multiplatform has no linux/windows-native
+  // target, so this module has no source for them. Declaring them produced
+  // empty NO-SOURCE compilations whose publication failed (missing klib) during
+  // publishToMavenCentral. JVM Desktop covers Linux/Windows for Compose.
 
   @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class) wasmJs { browser() }
 


### PR DESCRIPTION
Fixes the failed Maven Central publish ([run 27117220819](https://github.com/hyeons-lab/prism/actions/runs/27117220819)).

## Failure
```
Execution failed for task ':prism-compose:generateMetadataFileForLinuxX64Publication'.
> java.io.FileNotFoundException: .../prism-compose/build/libs/prism-compose-linuxX64Main.klib (No such file or directory)
```
Not a credentials/signing issue — signing succeeded; this is a build failure.

## Root cause
`prism-compose` is the **only published module with no `commonMain` sources** — its code lives in `nonNativeMain` (jvm/android/wasm) and `appleMain` (ios/macos). It declared `linuxX64()`/`mingwX64()` targets that compiled nothing (`compileKotlinLinuxX64` = NO-SOURCE → no klib), but the publication still ran `generateMetadataFileForLinuxX64Publication`, which failed on the missing klib. Latent until the first full multiplatform `publishToMavenCentral`.

Compose Multiplatform has **no linux/windows Kotlin/Native target** — Linux and Windows are covered by the JVM Desktop target (which this module already has via `jvm()`). So those native targets were non-functional and only broke publishing.

## Fix
Remove `linuxX64()` and `mingwX64()` from `prism-compose`.

## Verification
- Audited all 11 published modules: only `prism-compose` has native targets without `commonMain` source; every other (incl. `prism-flutter`) has `commonMain`, so their klibs build/publish fine.
- `:prism-compose:publishToMavenLocal` → **BUILD SUCCESSFUL** (Android/iOS/JVM/macOS/WasmJs/root publications, no Linux/Mingw).
- `publish(LinuxX64|MingwX64)Publication` tasks no longer exist; `ktfmtCheck` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyeons-lab/codesmith/prism/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783488076&installation_id=134193259&pr_number=61&repository=hyeons-lab%2Fprism&return_to=https%3A%2F%2Fgithub.com%2Fhyeons-lab%2Fprism%2Fpull%2F61&signature=65b4e0d551ff83ea6dfc11555fc3846fec443c04d08026440960558a7d06ec36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->